### PR TITLE
Add Google Cloud async DNS HTTP client

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -7,7 +7,6 @@ source =
 source =
    gordon_janitor_gcp
    .tox/*/lib/python*/site-packages/gordon_janitor_gcp
-   .tox/pypy/site-packages/gordon_janitor_gcp
 
 [report]
 show_missing = True

--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@
 
 .. desc-begin
 
-Google Cloud Platform (GCP) plugin for `gordon-janitor`_, an open-source service that checks cloud DNS records against a source of truth and submits corrections to `gordon`_.
+Google Cloud Platform (GCP) plugin for `gordon-janitor`_, an open-source service that checks Cloud DNS records against a source of truth (e.g. Compute Engine) and submits corrections to `gordon`_ via Google Pubsub.
 
 .. desc-end
 
@@ -15,9 +15,9 @@ Google Cloud Platform (GCP) plugin for `gordon-janitor`_, an open-source service
 Requirements
 ============
 
-* Python 3.6
+* Python 3.6. Support for other Python versions may be added in the future.
+* Service account JSON key that has Cloud DNS read access. See Google's `documentation`_ on how to create a key.
 
-Support for other Python versions may be added in the future.
 
 Development
 ===========
@@ -86,3 +86,4 @@ This project adheres to the `Open Code of Conduct`_. By participating, you are e
 .. _`Open Code of Conduct`: https://github.com/spotify/code-of-conduct/blob/master/code-of-conduct.md
 .. _`gordon`: https://github.com/spotify/gordon
 .. _`gordon-janitor`: https://github.com/spotify/gordon-janitor
+.. _`documentation`: https://cloud.google.com/iam/docs/creating-managing-service-account-keys

--- a/README.rst
+++ b/README.rst
@@ -76,6 +76,15 @@ To generate documentation:
 
 Then navigate to ``localhost:$PORT``!
 
+To watch for changes and automatically reload in the browser:
+
+.. code-block:: bash
+
+    (env) $ cd docs
+    (env) $ make livehtml  # default port 8888
+    # to change port
+    (env) $ make livehtml PORT=8080
+
 
 Code of Conduct
 ===============

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,2 +1,4 @@
 -r requirements.txt
 -r test-requirements.txt
+-r docs-requirements.txt
+sphinx-autobuild==0.7.1  # reload docs on changes

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -7,12 +7,17 @@ SPHINXBUILD   = sphinx-build
 SPHINXPROJ    = gordon-janitor-gcp
 SOURCEDIR     = .
 BUILDDIR      = _build
+PORT         := 8888
+
 
 # Put it first so that "make" without argument is like "make help".
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-.PHONY: help Makefile
+.PHONY: help livehtml Makefile
+
+livehtml:
+	sphinx-autobuild -p $(PORT) -b html $(SOURCEDIR) $(BUILDDIR)/html $(O)
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,11 +1,14 @@
 API Reference
 =============
 
-.. currentmodule:: gordon_janitor_gcp
 
 Asynchronous GCP HTTP Client
 ----------------------------
 
 .. automodule:: gordon_janitor_gcp.http_client
-.. autoclass:: gordon_janitor_gcp.http_client.AIOGoogleHTTPClient
-    :members:
+
+
+GCP Cloud DNS HTTP Client
+-------------------------
+
+.. automodule:: gordon_janitor_gcp.cloud_dns

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -103,6 +103,10 @@ pygments_style = 'sphinx'
 todo_include_todos = True
 
 
+# Autodoc extention configuration
+autodoc_member_order = 'bysource'  # not sure why this doesn't work?
+autodoc_default_flags = ['members']
+
 # -- Options for HTML output ----------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for

--- a/docs/exceptions.rst
+++ b/docs/exceptions.rst
@@ -1,0 +1,6 @@
+Exceptions
+==========
+
+Any exception that this module could throw.
+
+.. automodule:: gordon_janitor_gcp.exceptions

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,6 +25,7 @@ User's Guide
    :maxdepth: 1
 
    api
+   exceptions
 
 
 Project Information

--- a/gordon_janitor_gcp/cloud_dns.py
+++ b/gordon_janitor_gcp/cloud_dns.py
@@ -1,0 +1,124 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2018 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Client module to interact with the Google Cloud DNS API.
+
+This client makes use of the asynchronus HTTP client as defined in
+:py:mod:`gordon_janitor_gcp.http_client`, and therefore must use
+service account/JWT authentication (for now).
+
+To use:
+
+.. code-block:: pycon
+
+    >>> keyfile = '/path/to/service_account_keyfile.json'
+    >>> client = AIOGoogleDNSClient(
+    ...   project='my-dns-project', keyfile=keyfile)
+    >>> records = client.get_records_for_zone('testzone')
+    >>> print(records[0])
+    GCPResourceRecordSet(name='foo.testzone.com', type='A',
+                         rrdatas=['10.1.2.3'], ttl=300)
+
+"""
+
+import logging
+
+import attr
+
+from gordon_janitor_gcp import http_client
+
+
+@attr.s
+class GCPResourceRecordSet:
+    """DNS Resource Record Set.
+
+    Args:
+        name (str): Name/label.
+        type (str): Record type (see `Google's supported records
+            <https://cloud.google.com/dns/overview#supported_dns_r
+            ecord_types>`_ for valid types).
+        rrdatas (list): Record data according to RFC 1034§3.6.1 and
+            RFC 1035§5.
+        ttl (int): (optional) Number of seconds that the record set can
+            be cached by resolvers. Defaults to 300.
+    """
+    # TODO (lynn): This will be moved to a common package to be shared
+    #   between all of gordon* packages. It will also make use of attrs
+    #   ability to optionally validate upon creation.
+    name = attr.ib(type=str)
+    type = attr.ib(type=str)
+    rrdatas = attr.ib(type=list)
+    ttl = attr.ib(type=int, default=300)
+
+
+class AIOGoogleDNSClient(http_client.AIOGoogleHTTPClient):
+    """Async HTTP client to interact with Google Cloud DNS API.
+
+    Attributes:
+        BASE_URL (str): base call url for the DNS API
+
+    Args:
+        project (str): Google project ID that hosts the managed DNS.
+        keyfile (str): path to service account (SA) keyfile.
+        scopes (list): scopes with which to authorize the SA. Default is
+            ``['cloud-platform']``.
+        api_version (str): DNS API endpoint version. Defaults to ``v1``.
+        loop: asyncio event loop to use for HTTP requests.
+    """
+    BASE_URL = 'https://www.googleapis.com/dns'
+
+    def __init__(self, project=None, keyfile=None, scopes=None,
+                 api_version='v1', loop=None):
+        super().__init__(keyfile=keyfile, scopes=scopes, loop=loop)
+        self.project = project
+        self._base_url = f'{self.BASE_URL}/{api_version}/projects/{project}'
+
+    def _parse_resp_to_records(self, response, records):
+        unparsed_records = response.get('rrsets', [])
+        for record in unparsed_records:
+            rrset = GCPResourceRecordSet(**record)
+            records.append(rrset)
+
+    async def get_records_for_zone(self, zone):
+        """Get all resource record sets for a particular managed zone.
+
+        Args:
+            zone (str): Desired managed zone to query.
+        Returns:
+            list of :py:class:`GCPResourceRecordSet` instances.
+        """
+        url = f'{self._base_url}/managedZones/{zone}/rrsets'
+
+        # to limit the amount of data across the wire; also makes it
+        # easier to create GCPResourceRecordSet instances
+        fields = 'rrsets/name,rrsets/rrdatas,rrsets/type,rrsets/ttl'
+        params = {
+            'fields': fields,
+        }
+        next_page_token = None
+
+        records = []
+        while True:
+            if next_page_token:
+                params['pageToken'] = next_page_token
+            response = await self.get_json(url, params=params)
+            self._parse_resp_to_records(response, records)
+            next_page_token = response.get('nextPageToken')
+            if not next_page_token:
+                break
+
+        logging.info(f'Found {len(records)} for zone "{zone}".')
+        return records

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 aiohttp==2.3.9
+attrs==17.4.0
 google-auth==1.3.0

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2018 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Module for reusable pytest fixtures.
+"""
+import json
+
+import pytest
+from google.oauth2 import service_account
+
+
+API_BASE_URL = 'https://example.com'
+API_URL = f'{API_BASE_URL}/v1/foo_endpoint'
+
+
+@pytest.fixture
+def fake_keyfile_data():
+    return {
+        'type': 'service_account',
+        'project_id': 'a-test-project',
+        'private_key_id': 'yeahright',
+        'private_key': 'nope',
+        'client_email': 'test-key@a-test-project.iam.gserviceaccount.com',
+        'client_id': '12345678910',
+        'auth_uri': f'{API_BASE_URL}/auth',
+        'token_uri': f'{API_BASE_URL}/token',
+        'auth_provider_x509_cert_url': f'{API_BASE_URL}/certs',
+        'client_x509_cert_url': f'{API_BASE_URL}/x509/a-test-project'
+    }
+
+
+@pytest.fixture
+def fake_keyfile(fake_keyfile_data, tmpdir):
+    tmp_keyfile = tmpdir.mkdir('keys').join('fake_keyfile.json')
+    tmp_keyfile.write(json.dumps(fake_keyfile_data))
+    return tmp_keyfile
+
+
+@pytest.fixture
+def mock_credentials(mocker, monkeypatch):
+    mock_creds = mocker.MagicMock(service_account.Credentials, autospec=True)
+    sa_creds = mocker.MagicMock(service_account.Credentials, autospec=True)
+    sa_creds._make_authorization_grant_assertion.return_value = 'deadb33f=='
+    mock_creds.from_service_account_info.return_value = sa_creds
+
+    patch = 'gordon_janitor_gcp.http_client.service_account.Credentials'
+    monkeypatch.setattr(patch, mock_creds)
+    return mock_creds

--- a/tests/unit/test_cloud_dns.py
+++ b/tests/unit/test_cloud_dns.py
@@ -1,0 +1,150 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2018 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import logging
+
+import attr
+import pytest
+from aioresponses import aioresponses
+
+from gordon_janitor_gcp import cloud_dns
+
+
+def test_create_gcp_rrset():
+    """Create valid GCPResourceRecordSet instances."""
+    data = {
+        'name': 'test',
+        'type': 'A',
+        'rrdatas': ['10.1.2.3'],
+        'ttl': 500
+    }
+    rrset = cloud_dns.GCPResourceRecordSet(**data)
+    assert data == attr.asdict(rrset)
+
+    # default TTL when not provided
+    data.pop('ttl')
+    rrset = cloud_dns.GCPResourceRecordSet(**data)
+    data['ttl'] = 300
+    assert data == attr.asdict(rrset)
+
+    # Raise when required params are missing
+    missing_params = {
+        'name': 'test'
+    }
+    with pytest.raises(TypeError):
+        cloud_dns.GCPResourceRecordSet(**missing_params)
+
+
+args = 'scopes,provide_loop'
+params = [
+    [['not-a-real-scope'], True],
+    [['not-a-real-scope'], False],
+    [None, True],
+    [None, False],
+]
+
+
+@pytest.mark.parametrize(args, params)
+def test_dns_client_default(scopes, provide_loop, fake_keyfile,
+                            mock_credentials, event_loop):
+    loop = None
+    if provide_loop:
+        loop = event_loop
+
+    client = cloud_dns.AIOGoogleDNSClient(
+        'a-project', fake_keyfile, scopes, loop=loop)
+
+    assert 'a-project' == client.project
+    if not provide_loop:
+        loop = asyncio.get_event_loop()
+    assert loop == client._loop
+    if not scopes:
+        scopes = ['cloud-platform']
+    exp_scopes = [f'https://www.googleapis.com/auth/{s}' for s in scopes]
+
+    assert exp_scopes == client.scopes
+
+    client._session.close()
+
+
+@pytest.fixture
+def fake_response_data():
+    return {
+        'rrsets': [
+            {
+                'name': 'a-test.example.net.',
+                'type': 'A',
+                'ttl': 300,
+                'rrdatas': [
+                    '10.1.2.3',
+                ]
+            }, {
+                'name': 'b-test.example.net.',
+                'type': 'CNAME',
+                'ttl': 600,
+                'rrdatas': [
+                    'a-test.example.net.',
+                ]
+            }, {
+                'name': 'c-test.example.net.',
+                'type': 'TXT',
+                'ttl': 300,
+                'rrdatas': [
+                    '"OHAI"',
+                    '"OYE"',
+                ]
+            }
+        ]
+    }
+
+
+@pytest.fixture
+def client(fake_keyfile, mock_credentials):
+    client = cloud_dns.AIOGoogleDNSClient('a-project', keyfile=fake_keyfile)
+    yield client
+    # test teardown
+    client._session.close()
+
+
+@pytest.mark.asyncio
+async def test_get_records_for_zone(fake_response_data, client, caplog,
+                                    mock_credentials, monkeypatch):
+    caplog.set_level(logging.DEBUG)
+    mock_get_json_called = 0
+
+    async def mock_get_json(*args, **kwargs):
+        nonlocal mock_get_json_called
+        data = fake_response_data.copy()
+        if not mock_get_json_called:
+            data['nextPageToken'] = 1
+        mock_get_json_called += 1
+        return data
+
+    monkeypatch.setattr(client, 'get_json', mock_get_json)
+
+    url = f'{client._base_url}/managedZones/a-zone/rrsets'
+    with aioresponses() as mocked:
+        mocked.get(url, status=200)
+        # paginated requests
+        mocked.get(url, status=200)
+        records = await client.get_records_for_zone('a-zone')
+
+        assert all(
+            [isinstance(r, cloud_dns.GCPResourceRecordSet) for r in records])
+        assert 6 == len(records)
+
+    assert 1 == len(caplog.records)

--- a/tests/unit/test_http_client.py
+++ b/tests/unit/test_http_client.py
@@ -24,7 +24,6 @@ import aiohttp
 import pytest
 from aioresponses import aioresponses
 from google.oauth2 import _client as oauth_client
-from google.oauth2 import service_account
 
 from gordon_janitor_gcp import exceptions
 from gordon_janitor_gcp import http_client
@@ -32,41 +31,6 @@ from gordon_janitor_gcp import http_client
 
 API_BASE_URL = 'https://example.com'
 API_URL = f'{API_BASE_URL}/v1/foo_endpoint'
-
-
-@pytest.fixture
-def mock_credentials(mocker, monkeypatch):
-    mock_creds = mocker.MagicMock(service_account.Credentials, autospec=True)
-    sa_creds = mocker.MagicMock(service_account.Credentials, autospec=True)
-    sa_creds._make_authorization_grant_assertion.return_value = 'deadb33f=='
-    mock_creds.from_service_account_info.return_value = sa_creds
-
-    patch = 'gordon_janitor_gcp.http_client.service_account.Credentials'
-    monkeypatch.setattr(patch, mock_creds)
-    return mock_creds
-
-
-@pytest.fixture
-def fake_keyfile_data():
-    return {
-        'type': 'service_account',
-        'project_id': 'a-test-project',
-        'private_key_id': 'yeahright',
-        'private_key': 'nope',
-        'client_email': 'test-key@a-test-project.iam.gserviceaccount.com',
-        'client_id': '12345678910',
-        'auth_uri': f'{API_BASE_URL}/auth',
-        'token_uri': f'{API_BASE_URL}/token',
-        'auth_provider_x509_cert_url': f'{API_BASE_URL}/certs',
-        'client_x509_cert_url': f'{API_BASE_URL}/x509/a-test-project'
-    }
-
-
-@pytest.fixture
-def fake_keyfile(fake_keyfile_data, tmpdir):
-    tmp_keyfile = tmpdir.mkdir('keys').join('fake_keyfile.json')
-    tmp_keyfile.write(json.dumps(fake_keyfile_data))
-    return tmp_keyfile
 
 
 #####

--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,7 @@ commands = check-manifest
 show-source = true
 max-line-length = 80
 exclude = .venv,.tox,.git,dist,doc,*.egg,build
+ignore = E221
 import-order-style = edited
 application-import-names = gordon_janitor_gcp,tests
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines <https://github.com/spotify/gordon-janitor-gcp/blob/master/CONTRIBUTING.rst>
2. If the PR is unfinished, please prefix the subject line with [WIP], [DRAFT], or [RFC].
-->

**What this PR does / why we need it**:

Adding a client to interact with the Google DNS API using the async HTTP client added in #1 . So far, only one public method is defined - get all records for a given managed zone - but I anticipate that's all that we might need for now.

I've also fixed up docs and other no-op cleanups.

**Which issue(s) this PR fixes**
<!-- optional; in `fixes #<issue number>, fixes #<issue_number>, ...` format, will close the issue(s) when PR gets merged: -->

N/A

**Special notes for your reviewer**:

I am *totally* open to better names for anything!

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

@spotify/alf 