### PR TITLE
Add reconciler client for Google Cloud DNS

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -12,3 +12,9 @@ GCP Cloud DNS HTTP Client
 -------------------------
 
 .. automodule:: gordon_janitor_gcp.cloud_dns
+
+
+Reconciler
+----------
+
+.. automodule:: gordon_janitor_gcp.reconciler

--- a/gordon_janitor_gcp/reconciler.py
+++ b/gordon_janitor_gcp/reconciler.py
@@ -1,0 +1,249 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2018 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Module to compare desired record sets produced from a Resource Authority
+(i.e. ``GCEInstanceAuthority`` for Google Compute Engine) and actual
+record sets from Google Cloud DNS, then publish corrective messages to
+the internal ``changes_channel`` if there are differences.
+
+This client makes use of the asynchronous DNS client as defined in
+:py:mod:`gordon_janitor_gcp.cloud_dns`, and therefore must use
+service account/JWT authentication (for now).
+
+.. attention::
+
+    This reconciler client is an internal module for the core janitor
+    logic. No other user cases are expected.
+
+To use:
+
+.. code-block:: python
+
+    import asyncio
+
+    config = {
+        'keyfile': 'path/to/keyfile.json',
+        'scopes': ['dns-relevant-scope'],
+        'project': 'my-awesome-project'
+    }
+    rrset_chnl = asyncio.Queue()
+    changes_chnl = asyncio.Queue()
+
+    reconciler = GoogleDNSReconciler(
+        config, rrset_chnl, changes_chnl)
+
+    loop = asyncio.get_event_loop()
+    try:
+        loop.run_until_complete(reconciler.start())
+    finally:
+        loop.close()
+"""
+
+import asyncio
+import logging
+
+import attr
+
+from gordon_janitor_gcp import cloud_dns
+from gordon_janitor_gcp import exceptions
+
+
+class GoogleDNSReconciler:
+    """Validate current records in DNS against desired source of truth.
+
+    ``GoogleDNSReconciler`` will create a change message for the
+    configured publisher client plugin to consume if there is a
+    discrepancy between records in Google Cloud DNS and the desired
+    state.
+
+    Once validation is done, the Reconciler will emit a ``None`` message
+    to the ``changes_channel`` queue signalling to the ``Publisher``
+    (TODO: update name of publisher class once decided) that there are
+    no more change messages to expect.
+
+    Args:
+        config (dict): configuration for this Google Cloud DNS plugin.
+        rrset_channel (asyncio.Queue): queue from which to consume
+            record set messages to validate.
+        changes_channel (asyncio.Queue): queue to publish message to
+            make corrections to Cloud DNS.
+        timeout (int): (optional) seconds to wait for the plugin's tasks
+            to finish before emitting a ``None`` message to the
+            ``changes_channel``. Outstanding tasks will be cancelled
+            and logged. Defaults to 60.
+        loop: (optional) asyncio event loop to use for HTTP requests.
+    """
+
+    _ASYNC_METHODS = ['publish_change_messages', 'validate_rrsets_by_zone']
+
+    def __init__(self, config, rrset_channel, changes_channel, timeout=60,
+                 loop=None):
+        self.config = config
+        self.rrset_channel = rrset_channel
+        self.changes_channel = changes_channel
+        self.timeout = timeout
+        self._loop = loop or asyncio.get_event_loop()
+        self.dns_client = self._get_dns_client()
+
+    def _get_dns_client(self):
+        keyfile = self.config.get('keyfile')
+        scopes = self.config.get('scopes')
+        project = self.config.get('project')
+        api_version = self.config.get('api_version', 'v1')
+
+        return cloud_dns.AIOGoogleDNSClient(
+            keyfile=keyfile, project=project, scopes=scopes,
+            api_version=api_version, loop=self._loop
+        )
+
+    async def done(self):
+        """Clean up and notify ``changes_channel`` of no more messages.
+
+        This method collects all tasks that this particular class
+        initiated, and will cancel them if they don't complete within
+        the configured timeout period.
+
+        Once all tasks are done, `None` is added to the
+        :py:obj:`self.changes_channel` to signify that it has no
+        more work to process. Then the HTTP session attached to the
+        :py:obj:`self.dns_client` is properly closed.
+        """
+        all_tasks = asyncio.Task.all_tasks()
+        tasks_to_clear = [
+            t for t in all_tasks if t._coro.__name__ in self._ASYNC_METHODS
+        ]
+        sleep_for = 0.5  # half a second
+        iterations = self.timeout / sleep_for
+
+        while iterations:
+            tasks_to_clear = [t for t in tasks_to_clear if not t.done()]
+            if not tasks_to_clear:
+                break
+
+            await asyncio.sleep(sleep_for)
+            iterations -= 1
+
+        # give up on waiting for tasks to complete
+        if tasks_to_clear:
+            msg = (f'The following tasks did not complete in time and are '
+                   f'being cancelled: {tasks_to_clear}')
+            logging.warning(msg)
+            for task in tasks_to_clear:
+                task.cancel()
+
+        await self.changes_channel.put(None)
+        # TODO (lynn): add metrics.flush call here once aioshumway is released
+        self.dns_client._session.close()
+
+        msg = ('Reconciliation of desired records against actual records in '
+               'Google DNS is complete.')
+        logging.info(msg)
+
+    async def publish_change_messages(self, desired_rrsets, action='additions'):
+        """Publish change messages to the ``changes_channel``.
+
+        NOTE: Only `'additions'` are currently supported. `'deletions'`
+        may be supported in the future.
+
+        Args:
+            desired_rrsets (list(GCPResourceRecordSet)): Desired record
+                sets that are not in Google Cloud DNS.
+            action (str): (optional) action for these corrective
+                messages. Defaults to ``'additions'``.
+        """
+        for rrset in desired_rrsets:
+            msg = {
+                'resourceRecords': attr.asdict(rrset),
+                'action': action
+            }
+            # TODO (lynn): add metrics.incr call here once aioshumway is
+            #              released
+            logging.debug('Creating the following change message: {msg}')
+            await self.changes_channel.put(msg)
+
+        logging.info(f'Created {len(desired_rrsets)} change messages.')
+
+    def _parse_rrset_message(self, message):
+        # assert that keys 'zone' and 'rrsets' are present, and return
+        # values for each
+        try:
+            zone = message['zone']
+        except KeyError:
+            msg = (f'No zone was defined in the given message: {message}.')
+            logging.error(msg)
+            raise exceptions.GCPGordonJanitorError(msg)
+        try:
+            rrsets = message['rrsets']
+        except KeyError:
+            msg = (f'No resource record sets were defined in given message: '
+                   f'{message}.')
+            logging.error(msg)
+            raise exceptions.GCPGordonJanitorError(msg)
+
+        return zone, rrsets
+
+    async def validate_rrsets_by_zone(self, zone, rrsets):
+        """Given a zone, validate current versus desired rrsets.
+
+        If there are any missing records, a corrective message for each
+        record will be published.
+
+        Args:
+            zone (str): zone to query Google Cloud DNS API.
+            rrsets (list): desired record sets to which to compare the
+                Cloud DNS API's response.
+        """
+        desired_rrsets = [
+            cloud_dns.GCPResourceRecordSet(**record) for record in rrsets
+        ]
+
+        actual_rrsets = await self.dns_client.get_records_for_zone(zone)
+
+        # NOTE: only working on "additions" (which includes changes to
+        #       current records) right now.
+        # TODO: (FEATURE) add support for cleaning up records that
+        #       should have been deleted.
+        missing_rrsets = [
+            rs for rs in desired_rrsets if rs not in actual_rrsets
+        ]
+        msg = (f'[{zone}] Processed {len(actual_rrsets)} rrset messages '
+               f'and found {len(missing_rrsets)} missing rrsets.')
+        logging.info(msg)
+        # TODO (lynn): emit or incr metric of missing_rrsets by zone once
+        #              aioshumway is released
+        # TODO: (FEATURE): have separate metrics for additions and deletions
+        await self.publish_change_messages(missing_rrsets, action='additions')
+
+    async def start(self):
+        """Start consuming from :py:obj:`self.rrset_channel`.
+
+        Once ``None`` is received from the channel, finish processing
+        records and emit a ``None`` message to the
+        :py:obj:`self.changes_channel`.
+        """
+        while True:
+            desired_rrset = await self.rrset_channel.get()
+            if desired_rrset is None:
+                break
+            # TODO: emit metric of message received once aioshumway is released
+            try:
+                zone, raw_rrsets = self._parse_rrset_message(desired_rrset)
+                await self.validate_rrsets_by_zone(zone, raw_rrsets)
+            except exceptions.GCPGordonJanitorError as e:
+                msg = f'Dropping message {desired_rrset}: {e}'
+                logging.error(msg, exc_info=e)
+
+        await self.done()

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -59,3 +59,34 @@ def mock_credentials(mocker, monkeypatch):
     patch = 'gordon_janitor_gcp.http_client.service_account.Credentials'
     monkeypatch.setattr(patch, mock_creds)
     return mock_creds
+
+
+@pytest.fixture
+def fake_response_data():
+    return {
+        'rrsets': [
+            {
+                'name': 'a-test.example.net.',
+                'type': 'A',
+                'ttl': 300,
+                'rrdatas': [
+                    '10.1.2.3',
+                ]
+            }, {
+                'name': 'b-test.example.net.',
+                'type': 'CNAME',
+                'ttl': 600,
+                'rrdatas': [
+                    'a-test.example.net.',
+                ]
+            }, {
+                'name': 'c-test.example.net.',
+                'type': 'TXT',
+                'ttl': 300,
+                'rrdatas': [
+                    '"OHAI"',
+                    '"OYE"',
+                ]
+            }
+        ]
+    }

--- a/tests/unit/test_cloud_dns.py
+++ b/tests/unit/test_cloud_dns.py
@@ -82,37 +82,6 @@ def test_dns_client_default(scopes, provide_loop, fake_keyfile,
 
 
 @pytest.fixture
-def fake_response_data():
-    return {
-        'rrsets': [
-            {
-                'name': 'a-test.example.net.',
-                'type': 'A',
-                'ttl': 300,
-                'rrdatas': [
-                    '10.1.2.3',
-                ]
-            }, {
-                'name': 'b-test.example.net.',
-                'type': 'CNAME',
-                'ttl': 600,
-                'rrdatas': [
-                    'a-test.example.net.',
-                ]
-            }, {
-                'name': 'c-test.example.net.',
-                'type': 'TXT',
-                'ttl': 300,
-                'rrdatas': [
-                    '"OHAI"',
-                    '"OYE"',
-                ]
-            }
-        ]
-    }
-
-
-@pytest.fixture
 def client(fake_keyfile, mock_credentials):
     client = cloud_dns.AIOGoogleDNSClient('a-project', keyfile=fake_keyfile)
     yield client

--- a/tests/unit/test_reconciler.py
+++ b/tests/unit/test_reconciler.py
@@ -1,0 +1,221 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2018 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import logging
+
+import pytest
+
+from gordon_janitor_gcp import cloud_dns
+from gordon_janitor_gcp import reconciler
+
+
+@pytest.fixture
+def minimal_config(fake_keyfile):
+    return {
+        'keyfile': fake_keyfile,
+        'scopes': ['my-awesome-scope'],
+        'project': 'a-project',
+    }
+
+
+@pytest.fixture
+def full_config(minimal_config):
+    minimal_config['api_version'] = 'zeta'
+    return minimal_config
+
+
+args = 'config_type,timeout,provide_loop'
+params = [
+    ['minimal', False, False],
+    ['full', 80, True],
+]
+
+
+@pytest.mark.parametrize(args, params)
+def test_reconciler_default(config_type, timeout, provide_loop, event_loop,
+                            minimal_config, full_config, mock_credentials):
+    """GoogleDNSReconciler is created with expected attribute values."""
+    loop = None
+    if provide_loop:
+        loop = event_loop
+
+    config = minimal_config
+    if config_type == 'full':
+        config = full_config
+
+    kwargs = {
+        'config': config,
+        'rrset_channel': asyncio.Queue(),
+        'changes_channel': asyncio.Queue(),
+        'loop': loop,
+    }
+    if timeout:
+        kwargs['timeout'] = timeout
+
+    recon_client = reconciler.GoogleDNSReconciler(**kwargs)
+    if not provide_loop:
+        loop = asyncio.get_event_loop()
+    assert loop == recon_client._loop
+
+    if not timeout:
+        timeout = 60  # default
+    assert timeout == recon_client.timeout
+
+    recon_client.dns_client._session.close()
+
+
+@pytest.fixture
+async def recon_client(full_config, mock_credentials):
+    rch, chch = asyncio.Queue(), asyncio.Queue()
+    recon_client = reconciler.GoogleDNSReconciler(full_config, rch, chch)
+    yield recon_client
+    recon_client.dns_client._session.close()
+    while not chch.empty():
+        await chch.get()
+
+
+args = 'exp_log_records,timeout'
+params = [
+    # tasks did not complete before timeout
+    [2, 0],
+    # tasks completed before timeout
+    [1, 1],
+]
+
+
+@pytest.mark.parametrize(args, params)
+@pytest.mark.asyncio
+async def test_done(exp_log_records, timeout, recon_client, caplog, mocker,
+                    monkeypatch):
+    """Proper cleanup with or without pending tasks."""
+    caplog.set_level(logging.DEBUG)
+
+    recon_client.timeout = timeout
+
+    # mocked methods names must match those in reconciler._ASYNC_METHODS
+    async def publish_change_messages():
+        await asyncio.sleep(0)
+
+    async def validate_rrsets_by_zone():
+        await asyncio.sleep(0)
+
+    coro1 = asyncio.ensure_future(publish_change_messages())
+    coro2 = asyncio.ensure_future(validate_rrsets_by_zone())
+
+    mock_task = mocker.MagicMock(asyncio.Task, autospec=True)
+    mock_task.all_tasks.side_effect = [
+        # in the `while iterations` loop twice
+        # timeout of `0` will never hit this loop
+        [coro1, coro2],
+        [coro1.done(), coro2.done()]
+    ]
+    monkeypatch.setattr('gordon_janitor_gcp.reconciler.asyncio.Task', mock_task)
+
+    await recon_client.done()
+
+    assert exp_log_records == len(caplog.records)
+    if exp_log_records == 2:
+        # it's in a cancelling state which can't be directly tested
+        assert not coro1.done()
+        assert not coro2.done()
+    else:
+        assert coro1.done()
+        assert coro2.done()
+
+    assert 1 == recon_client.changes_channel.qsize()
+    assert recon_client.dns_client._session.closed
+
+
+@pytest.mark.asyncio
+async def test_publish_change_messages(recon_client, fake_response_data,
+                                       caplog):
+    """Publish message to changes queue."""
+    caplog.set_level(logging.DEBUG)
+    rrsets = fake_response_data['rrsets']
+    desired_rrsets = [cloud_dns.GCPResourceRecordSet(**kw) for kw in rrsets]
+
+    await recon_client.publish_change_messages(desired_rrsets)
+
+    assert 3 == recon_client.changes_channel.qsize()
+    assert 4 == len(caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_validate_rrsets_by_zone(recon_client, fake_response_data, caplog,
+                                       monkeypatch):
+    """A difference is detected and a change message is published."""
+    caplog.set_level(logging.DEBUG)
+    rrsets = fake_response_data['rrsets']
+
+    mock_get_records_for_zone_called = 0
+
+    async def mock_get_records_for_zone(*args, **kwargs):
+        nonlocal mock_get_records_for_zone_called
+        mock_get_records_for_zone_called += 1
+        rrsets = fake_response_data['rrsets']
+        rrsets[0]['rrdatas'] = ['10.4.5.6']
+        return [
+            cloud_dns.GCPResourceRecordSet(**kw) for kw in rrsets
+        ]
+
+    monkeypatch.setattr(
+        recon_client.dns_client, 'get_records_for_zone',
+        mock_get_records_for_zone
+    )
+
+    await recon_client.validate_rrsets_by_zone('example.net.', rrsets)
+
+    assert 1 == recon_client.changes_channel.qsize()
+    assert 3 == len(caplog.records)
+    assert 1 == mock_get_records_for_zone_called
+
+
+args = 'msg,exp_log_records,exp_mock_calls'
+params = [
+    # happy path
+    [{'zone': 'example.net.', 'rrsets': []}, 1, 1],
+    # no rrsets key
+    [{'zone': 'example.net.'}, 3, 0],
+    # no zone key
+    [{'rrsets': []}, 3, 0],
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(args, params)
+async def test_start(msg, exp_log_records, exp_mock_calls, caplog, recon_client,
+                     monkeypatch):
+    """Start reconciler & continue if certain errors are raised."""
+    caplog.set_level(logging.DEBUG)
+
+    mock_validate_rrsets_by_zone_called = 0
+
+    async def mock_validate_rrsets_by_zone(*args, **kwargs):
+        nonlocal mock_validate_rrsets_by_zone_called
+        mock_validate_rrsets_by_zone_called += 1
+        await asyncio.sleep(0)
+
+    monkeypatch.setattr(
+        recon_client, 'validate_rrsets_by_zone', mock_validate_rrsets_by_zone)
+
+    await recon_client.rrset_channel.put(msg)
+    await recon_client.rrset_channel.put(None)
+
+    await recon_client.start()
+
+    assert exp_log_records == len(caplog.records)
+    assert exp_mock_calls == mock_validate_rrsets_by_zone_called

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ usedevelop = True
 [testenv]
 setenv =
     PYTHONHASHSEED = 0
+    PYTHONASYNCIODEBUG = 1  ; tell us when asyncio tasks are destroyed before finished
 deps =-rdev-requirements.txt
 commands =
     /usr/bin/find . -name "*.pyc" -delete

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,6 @@ commands = check-manifest
 show-source = true
 max-line-length = 80
 exclude = .venv,.tox,.git,dist,doc,*.egg,build
-ignore = E221
 import-order-style = edited
 application-import-names = gordon_janitor_gcp,tests
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines <https://github.com/spotify/gordon-janitor-gcp/blob/master/CONTRIBUTING.rst>
2. If the PR is unfinished, please prefix the subject line with [WIP], [DRAFT], or [RFC].
-->

**What this PR does / why we need it**:

This compares the desired state (from either Compute Engine or elsewhere) versus actual state in Cloud DNS (making use of the client added in #3), then creates a change message. In a future PR, a publisher client will be added to consume those change messages and publish to a pubsub-like system (e.g. Google PubSub) that a Gordon service is configured to consume.

**Which issue(s) this PR fixes**
<!-- optional; in `fixes #<issue number>, fixes #<issue_number>, ...` format, will close the issue(s) when PR gets merged: -->

N/A

**Special notes for your reviewer**:

Two things of note:

* This only creates change messages to add missing records. It doesn't clean up stale records. The latter may be implemented latter if deemed needed.
* I've commented parts where metrics should be emitted from. This project is waiting on the finalization of making our [shumway](https://github.com/spotify/shumway) metrics library to be made async (working branch [here](https://github.com/spotify/aioshumway/tree/async_shumway)). I'd appreciate comments on parts where reviewers think there should be metrics added where I haven't left a comment in the code.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
