### PR TITLE
Move auth into its own client

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2,6 +2,45 @@ API Reference
 =============
 
 
+HTTP Sessions
+-------------
+
+By default, the HTTP session used for getting credentials is reused for
+API calls (recommended if there are many). If this is not desired, you
+can pass in your own ``aiohttp.ClientSession`` instance into
+``AIOGoogleDNSClient`` or ``AIOGoogleHTTPClient``. The auth client
+``GoogleAuthClient`` may also take an explicit session object, but is
+not required to assert a different HTTP session is used for the API
+calls.
+
+.. code-block:: python
+
+    import aiohttp
+
+    from gordon_janitor_gcp import auth
+    from gordon_janitor_gcp import cloud_dns
+    from gordon_janitor_gcp import http_client
+
+    keyfile = '/path/to/service_account_keyfile.json'
+    session = aiohttp.ClientSession()  # optional
+    auth_client = auth.GoogleAuthClient(
+        keyfile=keyfile, session=session
+    )
+
+    new_session = aiohttp.ClientSession()
+
+    # basic HTTP client
+    client = http_client.AIOGoogleHTTPClient(
+        auth_client=auth_client, session=new_session
+    )
+    # or DNS client
+    client = cloud_dns.AIOGoogleDNSClient(
+        project='my-dns-project', auth_client=auth_client,
+        session=new_session
+    )
+
+
+
 Asynchronous GCP HTTP Client
 ----------------------------
 
@@ -12,6 +51,12 @@ GCP Cloud DNS HTTP Client
 -------------------------
 
 .. automodule:: gordon_janitor_gcp.cloud_dns
+
+
+GCP Auth Client
+---------------
+
+.. automodule:: gordon_janitor_gcp.auth
 
 
 Reconciler

--- a/gordon_janitor_gcp/auth.py
+++ b/gordon_janitor_gcp/auth.py
@@ -1,0 +1,172 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2018 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Module to create a client interacting with Google Cloud authentication.
+
+An instantiated client is needed for interacting with any of the Google
+APIs via the ``gordon_janitor_gcp.http_client``.
+
+Only service account (JSON Web Tokens/JWT) authentication is currently
+supported. To setup a service account, follow `Google's docs <https://
+cloud.google.com/iam/docs/creating-managing-service-account-keys>`_.
+
+To use:
+
+.. code-block:: pycon
+
+    >>> import asyncio
+    >>> from google_janitor_gcp import auth
+    >>> loop = asyncio.get_event_loop()
+    >>> keyfile = '/path/to/service_account_keyfile.json'
+    >>> auth_client = auth.GoogleAuthClient(keyfile=keyfile)
+    >>> auth_clientcreds.token is None
+    True
+    >>> loop.run_until_complete(auth_client.refresh_token())
+    >>> auth_client.creds.token
+    'c0ffe3'
+
+"""
+
+import asyncio
+import json
+import logging
+import urllib.parse
+
+import aiohttp
+from google.oauth2 import _client
+from google.oauth2 import service_account
+
+from gordon_janitor_gcp import exceptions
+
+
+REQ_LOG_FMT = 'Request: "{method} {url}"'
+RESP_LOG_FMT = 'Response: "{method} {url}" {status} {reason}'
+
+
+class GoogleAuthClient:
+    """Async client to authenticate against Google Cloud APIs.
+
+    Attributes:
+        SCOPE_TMPL_URL (str): template URL for Google auth scopes.
+        DEFAULT_SCOPE (str): default scope if not provided.
+        JWT_GRANT_TYPE (str): grant type header value when
+            requesting/refreshing an access token.
+
+    Args:
+        keyfile (str): path to service account (SA) keyfile.
+        scopes (list): (optional) scopes with which to authorize the SA.
+            Default is ``'cloud-platform'``.
+        session (aiohttp.ClientSession): (optional) ``aiohttp`` HTTP
+            session to use for sending requests.
+        loop: (optional) asyncio event loop to use for HTTP requests.
+            NOTE: if ``session`` is given, then ``loop`` will be ignored.
+            Otherwise, ``loop`` will be used to create a session, if
+            provided.
+
+    """
+
+    SCOPE_TMPL_URL = 'https://www.googleapis.com/auth/{scope}'
+    DEFAULT_SCOPE = 'cloud-platform'
+    JWT_GRANT_TYPE = 'urn:ietf:params:oauth:grant-type:jwt-bearer'
+
+    def __init__(self, keyfile=None, scopes=None, session=None, loop=None):
+        self._keydata = self._load_keyfile(keyfile)
+        self.scopes = self._set_scopes(scopes)
+        self.creds = self._load_credentials()
+        self._session = self._set_session(session, loop)
+        self.token = None
+        self.expiry = None  # UTC time
+
+    def _load_keyfile(self, keyfile):
+        try:
+            with open(keyfile, 'r') as f:
+                return json.load(f)
+        except FileNotFoundError as e:
+            msg = f'Keyfile {keyfile} was not found.'
+            logging.error(msg, exc_info=e)
+            raise exceptions.GCPGordonJanitorError(msg)
+        except json.JSONDecodeError as e:
+            msg = f'Keyfile {keyfile} is not valid JSON.'
+            logging.error(msg, exc_info=e)
+            raise exceptions.GCPGordonJanitorError(msg)
+
+    def _set_scopes(self, scopes):
+        if not scopes:
+            scopes = [self.DEFAULT_SCOPE]
+        return [self.SCOPE_TMPL_URL.format(scope=s) for s in scopes]
+
+    def _load_credentials(self):
+        # TODO (lynn): FEATURE - load other credentials like app default
+        return service_account.Credentials.from_service_account_info(
+            self._keydata, scopes=self.scopes)
+
+    def _set_session(self, session, loop):
+        if session is not None:
+            return session
+        if not loop:
+            loop = asyncio.get_event_loop()
+        session = aiohttp.ClientSession(loop=loop)
+        return session
+
+    def _setup_token_request(self):
+        url = self._keydata.get('token_uri')
+        headers = {
+            'Content-type': 'application/x-www-form-urlencoded',
+        }
+        body = {
+            'assertion': self.creds._make_authorization_grant_assertion(),
+            'grant_type': self.JWT_GRANT_TYPE,
+        }
+        body = urllib.parse.urlencode(body)
+        return url, headers, bytes(body.encode('utf-8'))
+
+    async def refresh_token(self):
+        """Refresh oauth access token attached to this HTTP session.
+
+        Raises:
+            exceptions.GCPAuthError: if no token was found in the
+                response.
+            exceptions.GCPHTTPError: if any exception occurred.
+        """
+        url, headers, body = self._setup_token_request()
+
+        logging.debug(REQ_LOG_FMT.format(method='POST', url=url))
+        async with self._session.post(url, headers=headers, data=body) as resp:
+            log_kw = {
+                'method': 'POST',
+                'url': url,
+                'status': resp.status,
+                'reason': resp.reason,
+            }
+            logging.debug(RESP_LOG_FMT.format(**log_kw))
+
+            # avoid leaky abstractions and wrap http errors with our own
+            try:
+                resp.raise_for_status()
+            except aiohttp.ClientResponseError as e:
+                msg = f'Issue connecting to {resp.url.host}: {e}'
+                logging.error(msg, exc_info=e)
+                raise exceptions.GCPHTTPError(msg)
+
+            response = await resp.json()
+            try:
+                self.token = response['access_token']
+            except KeyError:
+                msg = 'No access token in response.'
+                logging.error(msg)
+                raise exceptions.GCPAuthError(msg)
+
+        self.expiry = _client._parse_expiry(response)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -16,49 +16,8 @@
 """
 Module for reusable pytest fixtures.
 """
-import json
 
-import pytest
-from google.oauth2 import service_account
-
-
-API_BASE_URL = 'https://example.com'
-API_URL = f'{API_BASE_URL}/v1/foo_endpoint'
-
-
-@pytest.fixture
-def fake_keyfile_data():
-    return {
-        'type': 'service_account',
-        'project_id': 'a-test-project',
-        'private_key_id': 'yeahright',
-        'private_key': 'nope',
-        'client_email': 'test-key@a-test-project.iam.gserviceaccount.com',
-        'client_id': '12345678910',
-        'auth_uri': f'{API_BASE_URL}/auth',
-        'token_uri': f'{API_BASE_URL}/token',
-        'auth_provider_x509_cert_url': f'{API_BASE_URL}/certs',
-        'client_x509_cert_url': f'{API_BASE_URL}/x509/a-test-project'
-    }
-
-
-@pytest.fixture
-def fake_keyfile(fake_keyfile_data, tmpdir):
-    tmp_keyfile = tmpdir.mkdir('keys').join('fake_keyfile.json')
-    tmp_keyfile.write(json.dumps(fake_keyfile_data))
-    return tmp_keyfile
-
-
-@pytest.fixture
-def mock_credentials(mocker, monkeypatch):
-    mock_creds = mocker.MagicMock(service_account.Credentials, autospec=True)
-    sa_creds = mocker.MagicMock(service_account.Credentials, autospec=True)
-    sa_creds._make_authorization_grant_assertion.return_value = 'deadb33f=='
-    mock_creds.from_service_account_info.return_value = sa_creds
-
-    patch = 'gordon_janitor_gcp.http_client.service_account.Credentials'
-    monkeypatch.setattr(patch, mock_creds)
-    return mock_creds
+import pytest  # NOQA
 
 
 @pytest.fixture

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -17,6 +17,8 @@
 Module for reusable pytest fixtures.
 """
 
+import logging
+
 import pytest  # NOQA
 
 
@@ -49,3 +51,11 @@ def fake_response_data():
             }
         ]
     }
+
+
+@pytest.fixture
+def caplog(caplog):
+    """Set global test logging levels."""
+    caplog.set_level(logging.DEBUG)
+    logging.getLogger('asyncio').setLevel(logging.WARNING)
+    return caplog

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -1,0 +1,219 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2018 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import datetime
+import json
+import logging
+import os
+
+import aiohttp
+import pytest
+from aioresponses import aioresponses
+from google.oauth2 import _client as oauth_client
+from google.oauth2 import service_account
+
+from gordon_janitor_gcp import auth
+from gordon_janitor_gcp import exceptions
+
+
+API_BASE_URL = 'https://example.com'
+API_URL = f'{API_BASE_URL}/v1/foo_endpoint'
+
+
+@pytest.fixture
+def session():
+    session = aiohttp.ClientSession()
+    yield session
+    session.close()
+
+
+@pytest.fixture
+def mock_service_acct(mocker, monkeypatch):
+    mock_creds = mocker.MagicMock(service_account.Credentials, autospec=True)
+    sa_creds = mocker.MagicMock(service_account.Credentials, autospec=True)
+    sa_creds._make_authorization_grant_assertion.return_value = 'deadb33f=='
+    mock_creds.from_service_account_info.return_value = sa_creds
+
+    patch = 'gordon_janitor_gcp.auth.service_account.Credentials'
+    monkeypatch.setattr(patch, mock_creds)
+    return mock_creds
+
+
+@pytest.fixture
+def fake_keyfile_data():
+    return {
+        'type': 'service_account',
+        'project_id': 'a-test-project',
+        'private_key_id': 'yeahright',
+        'private_key': 'nope',
+        'client_email': 'test-key@a-test-project.iam.gserviceaccount.com',
+        'client_id': '12345678910',
+        'auth_uri': f'{API_BASE_URL}/auth',
+        'token_uri': f'{API_BASE_URL}/token',
+        'auth_provider_x509_cert_url': f'{API_BASE_URL}/certs',
+        'client_x509_cert_url': f'{API_BASE_URL}/x509/a-test-project'
+    }
+
+
+@pytest.fixture
+def fake_keyfile(fake_keyfile_data, tmpdir):
+    tmp_keyfile = tmpdir.mkdir('keys').join('fake_keyfile.json')
+    tmp_keyfile.write(json.dumps(fake_keyfile_data))
+    return tmp_keyfile
+
+
+#####
+# Tests for simple client instantiation
+#####
+args = 'scopes,provide_session,provide_loop'
+params = [
+    [['not-a-real-scope'], True, True],
+    [['not-a-real-scope'], True, False],
+    [['not-a-real-scope'], False, False],
+    [['not-a-real-scope'], False, True],
+    [None, True, True],
+    [None, True, False],
+    [None, True, False],
+    [None, False, False],
+]
+
+
+@pytest.mark.parametrize(args, params)
+def test_auth_client_default(scopes, provide_session, provide_loop, event_loop,
+                             fake_keyfile, fake_keyfile_data, mock_service_acct,
+                             session):
+    """GoogleAuthClient is created with expected attributes."""
+    kwargs = {
+        'keyfile': fake_keyfile,
+        'scopes': scopes,
+    }
+    if provide_session:
+        kwargs['session'] = session
+    if provide_loop:
+        kwargs['loop'] = event_loop
+
+    client = auth.GoogleAuthClient(**kwargs)
+
+    assert fake_keyfile_data == client._keydata
+
+    if not scopes:
+        scopes = ['cloud-platform']
+    exp_scopes = [f'https://www.googleapis.com/auth/{s}' for s in scopes]
+
+    assert exp_scopes == client.scopes
+    assert isinstance(client._session, aiohttp.client.ClientSession)
+
+    if provide_session:
+        assert session is client._session
+    else:
+        assert session is not client._session
+
+    if provide_loop and not provide_session:
+        assert event_loop is client._session.loop
+    else:
+        assert event_loop is not client._session.loop
+
+    assert not client.token
+    assert not client.expiry
+
+
+def test_auth_client_raises_json(tmpdir, caplog):
+    """Client initialization raises when keyfile not valid json."""
+    caplog.set_level(logging.DEBUG)
+
+    tmp_keyfile = tmpdir.mkdir('keys').join('broken_keyfile.json')
+    tmp_keyfile.write('broken json')
+
+    with pytest.raises(exceptions.GCPGordonJanitorError) as e:
+        auth.GoogleAuthClient(keyfile=tmp_keyfile)
+
+    e.match(f'Keyfile {tmp_keyfile} is not valid JSON.')
+    assert 1 == len(caplog.records)
+
+
+def test_auth_client_raises_not_found(tmpdir, caplog):
+    """Client initialization raises when keyfile not found."""
+    caplog.set_level(logging.DEBUG)
+
+    tmp_keydir = tmpdir.mkdir('keys')
+    no_keyfile = os.path.join(tmp_keydir, 'not-existent.json')
+
+    with pytest.raises(exceptions.GCPGordonJanitorError) as e:
+        auth.GoogleAuthClient(keyfile=no_keyfile)
+
+    e.match(f'Keyfile {no_keyfile} was not found.')
+    assert 1 == len(caplog.records)
+
+
+#####
+# Tests & fixtures for access token handling
+#####
+@pytest.fixture
+def mock_parse_expiry(mocker, monkeypatch):
+    mock = mocker.MagicMock(oauth_client, autospec=True)
+    mock._parse_expiry.return_value = datetime.datetime(2018, 1, 1, 12, 0, 0)
+    monkeypatch.setattr('gordon_janitor_gcp.auth._client', mock)
+    return mock
+
+
+@pytest.fixture
+def client(fake_keyfile, mock_service_acct, session, event_loop):
+    return auth.GoogleAuthClient(keyfile=fake_keyfile, session=session)
+
+
+@pytest.mark.asyncio
+async def test_refresh_token(client, fake_keyfile_data, mock_parse_expiry,
+                             caplog):
+    """Successfully refresh access token."""
+    caplog.set_level(logging.DEBUG)
+
+    url = fake_keyfile_data['token_uri']
+    token = 'c0ffe3'
+    payload = {
+        'access_token': token,
+        'expires_in': 3600,  # seconds = 1hr
+    }
+    with aioresponses() as mocked:
+        mocked.post(url, status=200, payload=payload)
+        await client.refresh_token()
+    assert token == client.token
+    assert 2 == len(caplog.records)
+
+
+args = 'status,payload,exc,err_msg'
+params = [
+    [504, None, exceptions.GCPHTTPError, 'Issue connecting to example.com'],
+    [200, {}, exceptions.GCPAuthError, 'No access token in response.'],
+]
+
+
+@pytest.mark.parametrize(args, params)
+@pytest.mark.asyncio
+async def test_refresh_token_raises(status, payload, exc, err_msg, client,
+                                    fake_keyfile_data, caplog):
+    """Response errors from attempting to refresh token."""
+    caplog.set_level(logging.DEBUG)
+
+    url = fake_keyfile_data['token_uri']
+
+    with aioresponses() as mocked:
+        mocked.post(url, status=status, payload=payload)
+        with pytest.raises(exc) as e:
+            await client.refresh_token()
+
+        e.match(err_msg)
+
+    assert 3 == len(caplog.records)

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -28,6 +28,8 @@ from google.oauth2 import service_account
 from gordon_janitor_gcp import auth
 from gordon_janitor_gcp import exceptions
 
+logging.getLogger('asyncio').setLevel(logging.WARNING)
+
 
 API_BASE_URL = 'https://example.com'
 API_URL = f'{API_BASE_URL}/v1/foo_endpoint'
@@ -132,8 +134,6 @@ def test_auth_client_default(scopes, provide_session, provide_loop, event_loop,
 
 def test_auth_client_raises_json(tmpdir, caplog):
     """Client initialization raises when keyfile not valid json."""
-    caplog.set_level(logging.DEBUG)
-
     tmp_keyfile = tmpdir.mkdir('keys').join('broken_keyfile.json')
     tmp_keyfile.write('broken json')
 
@@ -146,8 +146,6 @@ def test_auth_client_raises_json(tmpdir, caplog):
 
 def test_auth_client_raises_not_found(tmpdir, caplog):
     """Client initialization raises when keyfile not found."""
-    caplog.set_level(logging.DEBUG)
-
     tmp_keydir = tmpdir.mkdir('keys')
     no_keyfile = os.path.join(tmp_keydir, 'not-existent.json')
 
@@ -178,8 +176,6 @@ def client(fake_keyfile, mock_service_acct, session, event_loop):
 async def test_refresh_token(client, fake_keyfile_data, mock_parse_expiry,
                              caplog):
     """Successfully refresh access token."""
-    caplog.set_level(logging.DEBUG)
-
     url = fake_keyfile_data['token_uri']
     token = 'c0ffe3'
     payload = {
@@ -205,8 +201,6 @@ params = [
 async def test_refresh_token_raises(status, payload, exc, err_msg, client,
                                     fake_keyfile_data, caplog):
     """Response errors from attempting to refresh token."""
-    caplog.set_level(logging.DEBUG)
-
     url = fake_keyfile_data['token_uri']
 
     with aioresponses() as mocked:

--- a/tests/unit/test_cloud_dns.py
+++ b/tests/unit/test_cloud_dns.py
@@ -14,13 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import asyncio
 import logging
 
+import aiohttp
 import attr
 import pytest
 from aioresponses import aioresponses
 
+from gordon_janitor_gcp import auth
 from gordon_janitor_gcp import cloud_dns
 
 
@@ -49,41 +50,28 @@ def test_create_gcp_rrset():
         cloud_dns.GCPResourceRecordSet(**missing_params)
 
 
-args = 'scopes,provide_loop'
-params = [
-    [['not-a-real-scope'], True],
-    [['not-a-real-scope'], False],
-    [None, True],
-    [None, False],
-]
-
-
-@pytest.mark.parametrize(args, params)
-def test_dns_client_default(scopes, provide_loop, fake_keyfile,
-                            mock_credentials, event_loop):
-    loop = None
-    if provide_loop:
-        loop = event_loop
+def test_dns_client_default(mocker):
+    auth_client = mocker.Mock(auth.GoogleAuthClient, autospec=True)
+    creds = mocker.Mock()
+    auth_client.creds = creds
+    session = aiohttp.ClientSession()
 
     client = cloud_dns.AIOGoogleDNSClient(
-        'a-project', fake_keyfile, scopes, loop=loop)
+        'a-project', auth_client, session=session)
 
     assert 'a-project' == client.project
-    if not provide_loop:
-        loop = asyncio.get_event_loop()
-    assert loop == client._loop
-    if not scopes:
-        scopes = ['cloud-platform']
-    exp_scopes = [f'https://www.googleapis.com/auth/{s}' for s in scopes]
-
-    assert exp_scopes == client.scopes
 
     client._session.close()
 
 
 @pytest.fixture
-def client(fake_keyfile, mock_credentials):
-    client = cloud_dns.AIOGoogleDNSClient('a-project', keyfile=fake_keyfile)
+def client(mocker):
+    auth_client = mocker.Mock(auth.GoogleAuthClient, autospec=True)
+    creds = mocker.Mock()
+    auth_client.creds = creds
+    session = aiohttp.ClientSession()
+    client = cloud_dns.AIOGoogleDNSClient(
+        'a-project', auth_client=auth_client, session=session)
     yield client
     # test teardown
     client._session.close()
@@ -91,7 +79,7 @@ def client(fake_keyfile, mock_credentials):
 
 @pytest.mark.asyncio
 async def test_get_records_for_zone(fake_response_data, client, caplog,
-                                    mock_credentials, monkeypatch):
+                                    monkeypatch):
     caplog.set_level(logging.DEBUG)
     mock_get_json_called = 0
 

--- a/tests/unit/test_cloud_dns.py
+++ b/tests/unit/test_cloud_dns.py
@@ -25,6 +25,9 @@ from gordon_janitor_gcp import auth
 from gordon_janitor_gcp import cloud_dns
 
 
+logging.getLogger('asyncio').setLevel(logging.WARNING)
+
+
 def test_create_gcp_rrset():
     """Create valid GCPResourceRecordSet instances."""
     data = {
@@ -80,7 +83,6 @@ def client(mocker):
 @pytest.mark.asyncio
 async def test_get_records_for_zone(fake_response_data, client, caplog,
                                     monkeypatch):
-    caplog.set_level(logging.DEBUG)
     mock_get_json_called = 0
 
     async def mock_get_json(*args, **kwargs):

--- a/tests/unit/test_http_client.py
+++ b/tests/unit/test_http_client.py
@@ -14,17 +14,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import asyncio
 import datetime
 import json
 import logging
-import os
 
 import aiohttp
 import pytest
 from aioresponses import aioresponses
-from google.oauth2 import _client as oauth_client
 
+from gordon_janitor_gcp import auth
 from gordon_janitor_gcp import exceptions
 from gordon_janitor_gcp import http_client
 
@@ -36,135 +34,28 @@ API_URL = f'{API_BASE_URL}/v1/foo_endpoint'
 #####
 # Tests for simple client instantiation
 #####
-args = 'scopes,provide_loop'
-params = [
-    [['not-a-real-scope'], True],
-    [['not-a-real-scope'], False],
-    [None, True],
-    [None, False],
-]
-
-
-@pytest.mark.parametrize(args, params)
-def test_http_client_default(scopes, provide_loop, event_loop, fake_keyfile,
-                             fake_keyfile_data, mock_credentials):
+@pytest.mark.parametrize('provide_session', [True, False])
+def test_http_client_default(provide_session, mocker):
     """AIOGoogleHTTPClient is created with expected attributes."""
-    loop = None
-    if provide_loop:
-        loop = event_loop
+    session = None
+    if provide_session:
+        session = aiohttp.ClientSession()
 
-    client = http_client.AIOGoogleHTTPClient(
-        keyfile=fake_keyfile, scopes=scopes, loop=loop
-    )
-    assert fake_keyfile_data == client._keydata
+    auth_client = mocker.Mock(auth.GoogleAuthClient, autospec=True)
+    auth_client._session = aiohttp.ClientSession()
+    creds = mocker.Mock()
+    auth_client.creds = creds
+    client = http_client.AIOGoogleHTTPClient(auth_client=auth_client,
+                                             session=session)
 
-    if not scopes:
-        scopes = ['cloud-platform']
-    exp_scopes = [f'https://www.googleapis.com/auth/{s}' for s in scopes]
-
-    assert exp_scopes == client.scopes
-
-    if not provide_loop:
-        loop = asyncio.get_event_loop()
-    assert loop == client._loop
-
-    assert isinstance(client._session, aiohttp.client.ClientSession)
-    assert not client.token
-    assert not client.expiry
+    if provide_session:
+        assert session is client._session
+        assert auth_client._session is not client._session
+    else:
+        assert auth_client._session is client._session
+        assert session is not client._session
 
     client._session.close()
-
-
-def test_http_client_raises_json(tmpdir, caplog):
-    """Client initialization raises when keyfile not valid json."""
-    caplog.set_level(logging.DEBUG)
-
-    tmp_keyfile = tmpdir.mkdir('keys').join('broken_keyfile.json')
-    tmp_keyfile.write('broken json')
-
-    with pytest.raises(exceptions.GCPGordonJanitorError) as e:
-        http_client.AIOGoogleHTTPClient(keyfile=tmp_keyfile)
-
-    e.match(f'Keyfile {tmp_keyfile} is not valid JSON.')
-    assert 1 == len(caplog.records)
-
-
-def test_http_client_raises_not_found(tmpdir, caplog):
-    """Client initialization raises when keyfile not found."""
-    caplog.set_level(logging.DEBUG)
-
-    tmp_keydir = tmpdir.mkdir('keys')
-    no_keyfile = os.path.join(tmp_keydir, 'not-existent.json')
-
-    with pytest.raises(exceptions.GCPGordonJanitorError) as e:
-        http_client.AIOGoogleHTTPClient(keyfile=no_keyfile)
-
-    e.match(f'Keyfile {no_keyfile} was not found.')
-    assert 1 == len(caplog.records)
-
-
-#####
-# Tests & fixtures for access token handling
-#####
-@pytest.fixture
-def mock_parse_expiry(mocker, monkeypatch):
-    mock = mocker.MagicMock(oauth_client, autospec=True)
-    mock._parse_expiry.return_value = datetime.datetime(2018, 1, 1, 12, 0, 0)
-    monkeypatch.setattr('gordon_janitor_gcp.http_client._client', mock)
-    return mock
-
-
-@pytest.fixture
-def client(fake_keyfile, mock_credentials):
-    client = http_client.AIOGoogleHTTPClient(keyfile=fake_keyfile)
-    yield client
-    # test teardown
-    client._session.close()
-
-
-@pytest.mark.asyncio
-async def test_refresh_token(client, fake_keyfile_data, mock_parse_expiry,
-                             caplog):
-    """Successfully refresh access token."""
-    caplog.set_level(logging.DEBUG)
-
-    url = fake_keyfile_data['token_uri']
-    token = 'c0ffe3'
-    payload = {
-        'access_token': token,
-        'expires_in': 3600,  # seconds = 1hr
-    }
-    with aioresponses() as mocked:
-        mocked.post(url, status=200, payload=payload)
-        await client.refresh_token()
-    assert token == client.token
-    assert 2 == len(caplog.records)
-
-
-args = 'status,payload,exc,err_msg'
-params = [
-    [504, None, exceptions.GCPHTTPError, 'Issue connecting to example.com'],
-    [200, {}, exceptions.GCPAuthError, 'No access token in response.'],
-]
-
-
-@pytest.mark.parametrize(args, params)
-@pytest.mark.asyncio
-async def test_refresh_token_raises(status, payload, exc, err_msg, client,
-                                    fake_keyfile_data, caplog):
-    """Response errors from attempting to refresh token."""
-    caplog.set_level(logging.DEBUG)
-
-    url = fake_keyfile_data['token_uri']
-
-    with aioresponses() as mocked:
-        mocked.post(url, status=status, payload=payload)
-        with pytest.raises(exc) as e:
-            await client.refresh_token()
-
-        e.match(err_msg)
-
-    assert 3 == len(caplog.records)
 
 
 # pytest prevents monkeypatching datetime directly
@@ -172,6 +63,19 @@ class MockDatetime(datetime.datetime):
     @classmethod
     def utcnow(cls):
         return datetime.datetime(2018, 1, 1, 11, 30, 0)
+
+
+@pytest.fixture
+def client(mocker):
+    auth_client = mocker.Mock(auth.GoogleAuthClient, autospec=True)
+    creds = mocker.Mock()
+    creds.token = '0ldc0ffe3'
+    auth_client.creds = creds
+    session = aiohttp.ClientSession()
+    client = http_client.AIOGoogleHTTPClient(auth_client=auth_client,
+                                             session=session)
+    yield client
+    client._session.close()
 
 
 args = 'token,expiry,exp_mocked_refresh'
@@ -189,7 +93,7 @@ params = [
 
 @pytest.mark.parametrize(args, params)
 @pytest.mark.asyncio
-async def test_set_valid_token(client, token, expiry, exp_mocked_refresh,
+async def test_set_valid_token(token, expiry, exp_mocked_refresh, client,
                                monkeypatch):
     """Refresh tokens if invalid or not set."""
     datetime.datetime = MockDatetime
@@ -200,10 +104,11 @@ async def test_set_valid_token(client, token, expiry, exp_mocked_refresh,
         nonlocal mock_refresh_token_called
         mock_refresh_token_called += 1
 
-    client.token = token
-    client.expiry = expiry
+    client._auth_client.creds.token = token
+    client._auth_client.creds.expiry = expiry
 
-    monkeypatch.setattr(client, 'refresh_token', mock_refresh_token)
+    monkeypatch.setattr(
+        client._auth_client, 'refresh_token', mock_refresh_token)
 
     await client.set_valid_token()
     assert exp_mocked_refresh == mock_refresh_token_called

--- a/tests/unit/test_http_client.py
+++ b/tests/unit/test_http_client.py
@@ -27,6 +27,9 @@ from gordon_janitor_gcp import exceptions
 from gordon_janitor_gcp import http_client
 
 
+logging.getLogger('asyncio').setLevel(logging.WARNING)
+
+
 API_BASE_URL = 'https://example.com'
 API_URL = f'{API_BASE_URL}/v1/foo_endpoint'
 
@@ -120,8 +123,6 @@ async def test_set_valid_token(token, expiry, exp_mocked_refresh, client,
 @pytest.mark.asyncio
 async def test_request(client, monkeypatch, caplog):
     """HTTP GET request is successful."""
-    caplog.set_level(logging.DEBUG)
-
     mock_set_valid_token_called = 0
 
     async def mock_set_valid_token():
@@ -144,8 +145,6 @@ async def test_request(client, monkeypatch, caplog):
 @pytest.mark.asyncio
 async def test_request_refresh(client, monkeypatch, caplog):
     """HTTP GET request is successful while refreshing token."""
-    caplog.set_level(logging.DEBUG)
-
     mock_set_valid_token_called = 0
 
     async def mock_set_valid_token():
@@ -169,7 +168,6 @@ async def test_request_refresh(client, monkeypatch, caplog):
 @pytest.mark.asyncio
 async def test_request_max_refresh_reached(client, monkeypatch, caplog):
     """HTTP GET request is not successful from max refresh requests met."""
-    caplog.set_level(logging.DEBUG)
     mock_set_valid_token_called = 0
 
     async def mock_set_valid_token():
@@ -211,8 +209,6 @@ params = [
 @pytest.mark.asyncio
 async def test_get_json(json_func, exp_resp, client, monkeypatch, caplog):
     """HTTP GET request with JSON parsing."""
-    caplog.set_level(logging.DEBUG)
-
     mock_set_valid_token_called = 0
 
     async def mock_set_valid_token():

--- a/tests/unit/test_reconciler.py
+++ b/tests/unit/test_reconciler.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 
 import asyncio
-import logging
 
 import pytest
 
@@ -40,7 +39,6 @@ def full_config(minimal_config):
 
 @pytest.fixture
 def dns_client(mocker, monkeypatch):
-    # creds = mocker.Mock(auth.GoogleAuthClient, autospec=True)
     mock = mocker.Mock(cloud_dns.AIOGoogleDNSClient, autospec=True)
     mock._session = mocker.Mock()
     mock._session.close.return_value = True
@@ -95,8 +93,6 @@ params = [
 async def test_done(exp_log_records, timeout, recon_client, caplog, mocker,
                     monkeypatch):
     """Proper cleanup with or without pending tasks."""
-    caplog.set_level(logging.DEBUG)
-
     recon_client.timeout = timeout
 
     # mocked methods names must match those in reconciler._ASYNC_METHODS
@@ -136,7 +132,6 @@ async def test_done(exp_log_records, timeout, recon_client, caplog, mocker,
 async def test_publish_change_messages(recon_client, fake_response_data,
                                        caplog):
     """Publish message to changes queue."""
-    caplog.set_level(logging.DEBUG)
     rrsets = fake_response_data['rrsets']
     desired_rrsets = [cloud_dns.GCPResourceRecordSet(**kw) for kw in rrsets]
 
@@ -150,7 +145,6 @@ async def test_publish_change_messages(recon_client, fake_response_data,
 async def test_validate_rrsets_by_zone(recon_client, fake_response_data, caplog,
                                        monkeypatch):
     """A difference is detected and a change message is published."""
-    caplog.set_level(logging.DEBUG)
     rrsets = fake_response_data['rrsets']
 
     mock_get_records_for_zone_called = 0
@@ -192,8 +186,6 @@ params = [
 async def test_start(msg, exp_log_records, exp_mock_calls, caplog, recon_client,
                      monkeypatch):
     """Start reconciler & continue if certain errors are raised."""
-    caplog.set_level(logging.DEBUG)
-
     mock_validate_rrsets_by_zone_called = 0
 
     async def mock_validate_rrsets_by_zone(*args, **kwargs):


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines <https://github.com/spotify/gordon-janitor-gcp/blob/master/CONTRIBUTING.rst>
2. If the PR is unfinished, please prefix the subject line with [WIP], [DRAFT], or [RFC].
-->

**What this PR does / why we need it**:

I needed to separate out the credentials object from the http client in order to use it (and avoid repeated code) with the pubsub module provided by the `google-cloud-python` library (which makes use of grpc + channels).

**Which issue(s) this PR fixes**
<!-- optional; in `fixes #<issue number>, fixes #<issue_number>, ...` format, will close the issue(s) when PR gets merged: -->

N/A

**Special notes for your reviewer**:

Not addressed in this PR, but what I plan to do next/some point soon is the following:

* Add support for default credentials / handle if `keyfile` is `None`
* With that implemented, have the `creds` object for the http client be optional (and therefore try to discover the default creds)
* utils module for some shared code (i.e. `REQ_LOG_FMT`)

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

cc @matt0bi @spotify/alf 
