### PR TITLE
Add client to talk to Google PubSub

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -63,3 +63,9 @@ Reconciler
 ----------
 
 .. automodule:: gordon_janitor_gcp.gdns_reconciler
+
+
+Publisher
+----------
+
+.. automodule:: gordon_janitor_gcp.gpubsub_publisher

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -171,4 +171,7 @@ man_pages = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 # TODO (econchick@): Once gordon core docs are live, add here
-intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}
+intersphinx_mapping = {
+    'https://docs.python.org/3': None,
+    'https://googlecloudplatform.github.io/google-cloud-python/latest/': None,
+}

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -17,6 +17,7 @@ Configuration
 
 The following sections are supported:
 
+
 gcp
 ~~~
 
@@ -28,9 +29,13 @@ Any configuration key/value listed here may also be used in the specific plugin 
 
     While one global key for all plugins is supported, it's advised to create a key per plugin with only the permissions it requires. To setup a service account, follow `Google's docs on creating & managing service account keys <https://cloud.google.com/iam/docs/creating-managing-service-account-keys>`_.
 
+    .. attention::
+
+        For the Pub/Sub plugin, ``keyfile`` is not required when running against the `Pub/Sub Emulator <https://cloud.google.com/pubsub/docs/emulator>`_ that Google provides.
+
 .. option:: project="STR"
 
-    `Required`: Google Project ID which hosts the relevant GCP services (e.g. Cloud DNS, PubSub, Compute Engine).
+    `Required`: Google Project ID which hosts the relevant GCP services (e.g. Cloud DNS, Pub/Sub, Compute Engine).
 
     To learn more about GCP projects, please see `Google's docs on creating & managing projects <https://cloud.google.com/resource-manager/docs/creating-managing-projects>`_.
 
@@ -46,4 +51,17 @@ Any configuration key/value listed here may also be used in the specific plugin 
 gcp.gdns
 ~~~~~~~~
 
-All configuration options above may be used here. There are no specific DNS-related configuration options.
+All configuration options above in the general ``[gcp]`` may be used here. There are no specific DNS-related configuration options.
+
+gcp.gpubsub
+~~~~~~~~~~~
+
+All configuration options above in the general ``[gcp]`` may be used here. Additional Google Cloud Pub/Sub-related configuration is needed:
+
+.. option:: topic="STR"
+
+    `Required`: Google Pub/Sub topic to receive the publish change messages.
+
+.. attention::
+
+    For the Pub/Sub plugin, ``keyfile`` is not required when running against the `Pub/Sub Emulator <https://cloud.google.com/pubsub/docs/emulator>`_ that Google provides.

--- a/gordon-janitor.toml.example
+++ b/gordon-janitor.toml.example
@@ -9,3 +9,8 @@ cleanup_timeout = 60
 keyfile = "/path/to/dns-service-account.json"
 project = "gordon-dns-example"
 scopes = ["ndev.clouddns.readonly"]
+
+[gcp.gpubsub]
+keyfile = "/path/to/pubsub-service-account.json"
+project = "gordon-pubsub-example"
+topic = "dns-changes-topic"

--- a/gordon_janitor_gcp/gpubsub_publisher.py
+++ b/gordon_janitor_gcp/gpubsub_publisher.py
@@ -1,0 +1,240 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2018 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Client module to publish any required DNS changes initiated from
+:py:class:`gordon_janitor_gcp.gdns_reconciler.GoogleDNSReconciler` to
+Google Cloud Pub/Sub. The consumer of these messages is the `Gordon
+service <https://github.com/spotify/gordon>`_.
+
+This client wraps around `google-cloud-pubsub <https://pypi.python.org
+/pypi/google-cloud-pubsub>`_ using `grpc <https://github.com/googleapis/
+googleapis/blob/master/google/pubsub/v1/pubsub.proto>`_ rather than
+inheriting from :py:class:`gordon_janitor_gcp.http_client.\
+AIOGoogleHTTPClient`.
+
+.. attention::
+
+    This publisher client is an internal module for the core janitor
+    logic. No other use cases are expected.
+
+
+To use:
+
+.. code-block:: python
+
+    import asyncio
+
+    config = {
+        'keyfile': '/path/to/keyfile.json',
+        'project': 'a-dns-project',
+        'topic': 'a-topic',
+    }
+    changes_channel = asyncio.Queue()
+
+    publisher = get_publisher(config, changes_channel)
+
+    loop = asyncio.get_event_loop()
+    try:
+        loop.run_until_complete(publisher.start())
+    finally:
+        loop.close()
+"""
+
+import asyncio
+import datetime
+import json
+import logging
+import os
+
+import zope.interface
+from asyncio_extras import threads
+from google.api_core import exceptions as google_exceptions
+from google.cloud import pubsub
+from gordon_janitor import interfaces
+
+from gordon_janitor_gcp import auth
+from gordon_janitor_gcp import exceptions
+
+
+def _init_pubsub_client(auth_client, config):
+    # Silly emulator constraints
+    creds = getattr(auth_client, 'creds', None)
+    _client = pubsub.PublisherClient(credentials=creds)
+
+    topic = config['topic']
+    try:
+        _client.create_topic(topic)
+    except google_exceptions.AlreadyExists:
+        # already created
+        pass
+    except Exception as e:
+        msg = f'Error trying to create topic "{topic}": {e}'
+        logging.error(msg, exc_info=e)
+        raise exceptions.GCPGordonJanitorError(msg)
+
+    return _client
+
+
+def _init_pubsub_auth(config):
+    # a publisher client can't be made with credentials if a channel is
+    # already made/provided, which is what happens when the emulator is
+    # running ಠ_ಠ
+    # See (https://github.com/GoogleCloudPlatform/
+    #      google-cloud-python/pull/4839)
+    auth_client = None
+    if not os.environ.get('PUBSUB_EMULATOR_HOST'):
+        scopes = config.get('scopes')
+        # creating a dummy `session` as the pubsub.PublisherClient never
+        # uses it but without it aiohttp will complain about an unclosed
+        # client session that would otherwise be made by default
+        auth_client = auth.GoogleAuthClient(
+            keyfile=config['keyfile'], scopes=scopes, session='noop')
+    return auth_client
+
+
+def _validate_pubsub_config(config):
+    # req keys: keyfile, project, topic
+        # TODO (lynn): keyfile won't be required once we support other
+        #              auth methods
+    if not config.get('keyfile'):
+        msg = ('The path to a Service Account JSON keyfile is required to '
+               'authenticate for Google Cloud Pub/Sub.')
+        logging.error(msg)
+        raise exceptions.GCPConfigError(msg)
+    if not config.get('project'):
+        msg = 'The GCP project where Cloud Pub/Sub is located is required.'
+        logging.error(msg)
+        raise exceptions.GCPConfigError(msg)
+    if not config.get('topic'):
+        msg = ('A topic for the client to publish to in Cloud Pub/Sub is '
+               'required.')
+        logging.error(msg)
+        raise exceptions.GCPConfigError(msg)
+
+    topic_prefix = f'projects/{config["project"]}/topics/'
+    if not config.get('topic').startswith(topic_prefix):
+        config['topic'] = f'{topic_prefix}{config["topic"]}'
+
+
+def get_publisher(config, changes_channel, **kw):
+    """Get a GooglePubsubPublisher client.
+
+    A factory function that validates configuration, creates an auth
+    and pubsub API client, and returns a Google Pub/Sub Publisher
+    provider.
+
+    Args:
+        config (dict): Google Cloud Pub/Sub-related configuration.
+        changes_channel (asyncio.Queue): queue to publish message to
+            make corrections to Cloud DNS.
+        kw (dict): Additional keyword arguments to pass to the
+            Publisher.
+    Returns:
+        A :py:class:`GooglePubsubPublisher` instance.
+    """
+    _validate_pubsub_config(config)
+    auth_client = _init_pubsub_auth(config)
+    pubsub_client = _init_pubsub_client(auth_client, config)
+    return GooglePubsubPublisher(config, pubsub_client, changes_channel, **kw)
+
+
+@zope.interface.implementer(interfaces.IPublisher)
+class GooglePubsubPublisher:
+    """Client to publish change messages to Google Pub/Sub.
+
+    Args:
+        config (dict): Google Cloud Pub/Sub-related configuration.
+        publisher (google.cloud.pubsub_v1.publisher.client.Client):
+            client to interface with Google Pub/Sub API.
+        changes_channel (asyncio.Queue): queue to publish message to
+            make corrections to Cloud DNS.
+    """
+
+    def __init__(self, config, publisher, changes_channel=None, **kw):
+        self.topic = config['topic']
+        self.publisher = publisher
+        self.changes_channel = changes_channel
+        self.cleanup_timeout = config.get('cleanup_timeout', 60)
+        self._messages = set()
+
+    async def done(self):
+        """Clean up outstanding tasks and emit final logs + metrics.
+
+        This method collects all tasks that this particular class
+        initiated, and will cancel them if they don't complete within
+        the configured timeout period.
+        """
+        tasks_to_clear = [
+            t for t in self._messages if not t.done()
+        ]
+        sleep_for = 0.5  # half a second
+        iterations = self.cleanup_timeout / sleep_for
+
+        while iterations:
+            tasks_to_clear = [t for t in tasks_to_clear if not t.done()]
+            if not tasks_to_clear:
+                break
+
+            await asyncio.sleep(sleep_for)
+            iterations -= 1
+
+        # give up on waiting for tasks to complete
+        if tasks_to_clear:
+            msg = (f'The following tasks did not complete in time and are '
+                   f'being cancelled: {tasks_to_clear}')
+            logging.warning(msg)
+            for task in tasks_to_clear:
+                task.cancel()
+
+        # TODO (lynn): add metrics.flush call here once aioshumway is released
+        msg = ('Finished sending reconciliation messages to Google Pub/Sub.')
+        logging.info(msg)
+
+    @threads.threadpool
+    def publish(self, message):
+        """Publish received change message to Google Pub/Sub.
+
+        Args:
+            message (dict): change message received from the
+                ``self.changes_channel`` to emit.
+        """
+        message['timestamp'] = datetime.datetime.utcnow().isoformat()
+        bytes_message = bytes(json.dumps(message), encoding='utf-8')
+        future = self.publisher.publish(self.topic, bytes_message)
+
+        # collect to make sure everything's cleaned up once done
+        self._messages.add(future)
+        # TODO (lynn): add metrics.incr/emit call here once aioshumway
+        #              is released
+
+    async def start(self):
+        """Start consuming from :py:obj:`self._changes_channel`.
+
+        Once ``None`` is received from the channel, finish processing
+        records and clean up any outstanding tasks.
+        """
+        while True:
+            change_message = await self.changes_channel.get()
+            if change_message is None:
+                break
+            # TODO (lynn): emit metric of message received once
+            #              aioshumway is released
+            try:
+                await self.publish(change_message)
+            except Exception as e:  # todo
+                logging.error(f'foo: {e}')
+
+        await self.done()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,8 @@
 aiohttp==2.3.9
+asyncio-extras==1.3.0
 attrs==17.4.0
+google-api-core==0.1.4
 google-auth==1.3.0
+google-cloud-pubsub==0.30.1
+gordon-janitor==0.0.1.dev1
+zope.interface==4.4.3

--- a/setup.py
+++ b/setup.py
@@ -96,6 +96,7 @@ setup(
     entry_points={
         'gordon_janitor.plugins': [
             'gcp.gdns = gordon_janitor_gcp.gdns_reconciler.GoogleDNSReconciler',
+            'gcp.gpubsub = gordon_janitor_gcp.gpubsub_publisher:get_publisher',
         ],
     },
     classifiers=CLASSIFIERS,

--- a/tests/unit/gpubsub/__init__.py
+++ b/tests/unit/gpubsub/__init__.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2018 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/unit/test_gpubsub_publisher.py
+++ b/tests/unit/test_gpubsub_publisher.py
@@ -1,0 +1,217 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2018 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import concurrent.futures
+import datetime
+import json
+import logging
+
+import pytest
+from google.api_core import exceptions as google_exceptions
+from google.cloud import pubsub
+
+from gordon_janitor_gcp import exceptions
+from gordon_janitor_gcp import gpubsub_publisher
+from tests.unit import conftest
+
+
+@pytest.fixture
+def publisher_client(mocker, monkeypatch):
+    mock = mocker.Mock(pubsub.PublisherClient, autospec=True)
+    patch = 'gordon_janitor_gcp.gpubsub_publisher.pubsub.PublisherClient'
+    monkeypatch.setattr(patch, mock)
+    return mock
+
+
+@pytest.fixture
+def kwargs(config, publisher_client):
+    return {
+        'config': config,
+        'publisher': publisher_client,
+        'changes_channel': asyncio.Queue()
+    }
+
+
+@pytest.mark.parametrize('exp_log_records,timeout,side_effect', [
+    # tasks did not complete before timeout
+    [2, 0, (False, False)],
+    # tasks completed
+    [1, 1, (False, True)],
+    # tasks completed before timeout
+    [1, 1, (False, False, True)],
+])
+@pytest.mark.asyncio
+async def test_done(exp_log_records, timeout, side_effect, kwargs,
+                    publisher_client, auth_client, caplog, mocker,
+                    monkeypatch):
+    """Proper cleanup with or without pending tasks."""
+    caplog.set_level(logging.DEBUG)
+
+    mock_msg1 = mocker.Mock(concurrent.futures.Future, autospec=True)
+    mock_msg2 = mocker.Mock(concurrent.futures.Future, autospec=True)
+
+    if side_effect:
+        mock_msg1.done.side_effect = side_effect
+        mock_msg2.done.side_effect = side_effect
+
+    kwargs['config']['cleanup_timeout'] = timeout
+    client = gpubsub_publisher.GooglePubsubPublisher(**kwargs)
+    client._messages.add(mock_msg1)
+    client._messages.add(mock_msg2)
+
+    await client.done()
+
+    assert exp_log_records == len(caplog.records)
+    if exp_log_records == 2:
+        mock_msg1.cancel.assert_called_once()
+        mock_msg2.cancel.assert_called_once()
+
+    assert 0 == client.changes_channel.qsize()
+
+
+@pytest.mark.asyncio
+async def test_publish(kwargs, publisher_client, auth_client, mocker,
+                       monkeypatch):
+    """Publish received messages."""
+    datetime.datetime = conftest.MockDatetime
+
+    topic = kwargs['config']['topic']
+    project = kwargs['config']['project']
+    exp_topic = f'projects/{project}/topics/{topic}'
+    kwargs['config']['topic'] = exp_topic
+
+    client = gpubsub_publisher.GooglePubsubPublisher(**kwargs)
+
+    msg1 = {'message': 'one'}
+
+    await client.publish(msg1)
+
+    msg1['timestamp'] = datetime.datetime.utcnow().isoformat()
+    bytes_msg1 = bytes(json.dumps(msg1), encoding='utf-8')
+
+    publisher_client.publish.assert_called_once_with(exp_topic, bytes_msg1)
+    assert 1 == len(client._messages)
+
+
+@pytest.mark.parametrize('raises,exp_log_records', [
+    [False, 1],
+    [Exception('foo'), 2],
+])
+@pytest.mark.asyncio
+async def test_start(raises, exp_log_records, kwargs, publisher_client,
+                     auth_client, mocker, monkeypatch, caplog):
+    """Start consuming the changes channel queue."""
+    caplog.set_level(logging.DEBUG)
+
+    if raises:
+        publisher_client.publish.side_effect = [Exception('foo')]
+
+    msg1 = {'message': 'one'}
+    await kwargs['changes_channel'].put(msg1)
+    await kwargs['changes_channel'].put(None)
+
+    client = gpubsub_publisher.GooglePubsubPublisher(**kwargs)
+    await client.start()
+
+    publisher_client.publish.assert_called_once()
+    assert exp_log_records == len(caplog.records)
+
+
+@pytest.fixture
+def emulator(monkeypatch):
+    monkeypatch.delenv('PUBSUB_EMULATOR_HOST', raising=False)
+
+
+@pytest.mark.parametrize('local,timeout,exp_timeout,topic', [
+    (True, None, 60, 'a-topic'),
+    (False, 30, 30, 'projects/test-example/topics/a-topic'),
+])
+def test_get_publisher(local, timeout, exp_timeout, topic, config,
+                       auth_client, publisher_client, emulator, monkeypatch):
+    """Happy path to initialize a Publisher client."""
+    changes_chnl = asyncio.Queue()
+
+    if local:
+        monkeypatch.setenv('PUBSUB_EMULATOR_HOST', True)
+
+    if timeout:
+        config['cleanup_timeout'] = timeout
+
+    config['topic'] = topic
+    client = gpubsub_publisher.get_publisher(config, changes_chnl)
+
+    topic = topic.split('/')[-1]
+    exp_topic = f'projects/{config["project"]}/topics/{topic}'
+    assert exp_timeout == client.cleanup_timeout
+    assert client.publisher is not None
+    assert not client._messages
+
+    client.publisher.create_topic.assert_called_once_with(exp_topic)
+
+
+@pytest.mark.parametrize('config_key,exp_msg',  [
+    ('keyfile', 'The path to a Service Account JSON keyfile is required '),
+    ('project', 'The GCP project where Cloud Pub/Sub is located is required.'),
+    ('topic', ('A topic for the client to publish to in Cloud Pub/Sub is '
+               'required.')),
+])
+def test_get_publisher_config_raises(config_key, exp_msg, config, auth_client,
+                                     publisher_client, caplog, emulator):
+    """Raise with improper configuration."""
+    changes_chnl = asyncio.Queue()
+    config.pop(config_key)
+
+    with pytest.raises(exceptions.GCPConfigError) as e:
+        client = gpubsub_publisher.get_publisher(config, changes_chnl)
+        client.publisher.create_topic.assert_not_called()
+
+    e.match(exp_msg)
+    assert 1 == len(caplog.records)
+
+
+def test_get_publisher_raises(config, auth_client, publisher_client, caplog,
+                              emulator):
+    """Raise when there's an issue creating a Google Pub/Sub topic."""
+    changes_chnl = asyncio.Queue()
+    publisher_client.return_value.create_topic.side_effect = [Exception('fooo')]
+
+    with pytest.raises(exceptions.GCPGordonJanitorError) as e:
+        client = gpubsub_publisher.get_publisher(config, changes_chnl)
+
+        client.publisher.create_topic.assert_called_once_with(client.topic)
+        e.match(f'Error trying to create topic "{client.topic}"')
+
+    assert 1 == len(caplog.records)
+
+
+def test_get_publisher_topic_exists(config, auth_client, publisher_client,
+                                    emulator):
+    """Do not raise if topic already exists."""
+    changes_chnl = asyncio.Queue()
+    exp = google_exceptions.AlreadyExists('foo')
+    publisher_client.return_value.create_topic.side_effect = [exp]
+
+    short_topic = config['topic']
+    client = gpubsub_publisher.get_publisher(config, changes_chnl)
+
+    exp_topic = f'projects/{config["project"]}/topics/{short_topic}'
+    assert 60 == client.cleanup_timeout
+    assert client.publisher is not None
+    assert not client._messages
+    assert exp_topic == client.topic
+
+    client.publisher.create_topic.assert_called_once_with(exp_topic)

--- a/tests/unit/test_http_client.py
+++ b/tests/unit/test_http_client.py
@@ -25,7 +25,7 @@ from aioresponses import aioresponses
 from gordon_janitor_gcp import auth
 from gordon_janitor_gcp import exceptions
 from gordon_janitor_gcp import http_client
-
+from tests.unit import conftest
 
 logging.getLogger('asyncio').setLevel(logging.WARNING)
 
@@ -61,13 +61,6 @@ def test_http_client_default(provide_session, mocker):
     client._session.close()
 
 
-# pytest prevents monkeypatching datetime directly
-class MockDatetime(datetime.datetime):
-    @classmethod
-    def utcnow(cls):
-        return datetime.datetime(2018, 1, 1, 11, 30, 0)
-
-
 @pytest.fixture
 def client(mocker):
     auth_client = mocker.Mock(auth.GoogleAuthClient, autospec=True)
@@ -78,7 +71,7 @@ def client(mocker):
     client = http_client.AIOGoogleHTTPClient(auth_client=auth_client,
                                              session=session)
     yield client
-    client._session.close()
+    session.close()
 
 
 args = 'token,expiry,exp_mocked_refresh'
@@ -99,7 +92,7 @@ params = [
 async def test_set_valid_token(token, expiry, exp_mocked_refresh, client,
                                monkeypatch):
     """Refresh tokens if invalid or not set."""
-    datetime.datetime = MockDatetime
+    datetime.datetime = conftest.MockDatetime
 
     mock_refresh_token_called = 0
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines <https://github.com/spotify/gordon-janitor-gcp/blob/master/CONTRIBUTING.rst>
2. If the PR is unfinished, please prefix the subject line with [WIP], [DRAFT], or [RFC].
-->

**What this PR does / why we need it**:

This publisher client takes messages from the `changes_channel` queue and publishes a message to a Google Pub/Sub topic.

**Which issue(s) this PR fixes**
<!-- optional; in `fixes #<issue number>, fixes #<issue_number>, ...` format, will close the issue(s) when PR gets merged: -->
Fixes #

**Special notes for your reviewer**:

I tried to keep naming consistent w/i log messages and docstrings specifically for "Pub/Sub" (rather than "pubsub", "Pubsub", "PubSub") since that's how all of Google's prose reads. Let me know if I missed something.

I also added `TODO`s for where metrics could be collected/emitted. I'd appreciate comments where more metrics would be helpful that I missed.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

@spotify/alf 
