### PR TITLE
Add GCEClient and GCRMClient

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -69,3 +69,9 @@ Publisher
 ----------
 
 .. automodule:: gordon_janitor_gcp.gpubsub_publisher
+
+
+GCE Clients
+-----------
+
+.. automodule:: gordon_janitor_gcp.gcp_clients

--- a/gordon_janitor_gcp/gcp_clients.py
+++ b/gordon_janitor_gcp/gcp_clients.py
@@ -1,0 +1,223 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2018 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Client classes to retrieve project and instance data from GCE.
+
+These clients use the asynchronous HTTP client defined in
+:py:mod:`gordon_janitor_gcp.http_client` and require service account or
+JWT-token credentials for authentication.
+
+To use:
+
+.. code-block:: python
+
+    import asyncio
+
+    import aiohttp
+
+    from gordon_janitor_gcp import auth
+
+    loop = asyncio.get_event_loop()
+
+    async def main():
+        session = aiohttp.ClientSession()
+        auth_client = auth.GoogleAuthClient(
+            keyfile='/path/to/keyfile', session=session)
+        client = GCEClient(auth_client, session)
+        instances = await client.list_instances('project-id')
+        print(instances)
+
+    loop.run_until_complete(main())
+    # example output
+    # [{'hostname': 'instance-1', 'internal_ip': '10.10.10.10',
+    #   'external_ip': '192.168.1.10'}]
+"""
+
+import logging
+
+from gordon_janitor_gcp import http_client
+
+
+class GCRMClient(http_client.AIOGoogleHTTPClient,
+                 http_client.GPaginatorMixin):
+    """Async client to interact with Google Cloud Resource Manager API.
+
+    You can find the endpoint documentation
+    `here <https://cloud.google.com/resource-manager/
+    reference/rest/#rest-resource-v1projects>`__.
+
+    Attributes:
+        BASE_URL (str): Base endpoint URL.
+
+    Args:
+        auth_client (gordon_janitor_gcp.auth.GoogleAuthClient): client
+            to manage authentication for HTTP API requests.
+        session (aiohttp.ClientSession): (optional) ``aiohttp`` HTTP
+            session to use for sending requests. Defaults to the
+            session object attached to ``auth_client`` if not provided.
+        api_version (str): version of API endpoint to send requests to.
+    """
+    BASE_URL = 'https://cloudresourcemanager.googleapis.com'
+
+    def __init__(self, auth_client=None, session=None, api_version='v1'):
+        super().__init__(auth_client=auth_client, session=session)
+        self.api_version = api_version
+
+    def _parse_rsps_for_projects(self, responses):
+        projects = []
+        for response in responses:
+            for project in response.get('projects', []):
+                projects.append(project)
+        return projects
+
+    async def list_all_active_projects(self, page_size=1000):
+        """Get all active projects.
+
+        You can find the endpoint documentation
+        `here <https://cloud.google.com/resource-manager/
+        reference/rest/v1/projects/list>`__.
+
+        Args:
+            page_size (int): hint for the client to only retrieve up to this
+                number of results per API call.
+        Returns:
+            list: list of dicts of all active projects.
+        """
+        url = f'{self.BASE_URL}/{self.api_version}/projects'
+        params = {'pageSize': page_size}
+
+        responses = await self.list_all(url, params)
+        projects = self._parse_rsps_for_projects(responses)
+        return [
+            project for project in projects
+            if project.get('lifecycleState', '').lower() == 'active'
+        ]
+
+
+class GCEClient(http_client.AIOGoogleHTTPClient,
+                http_client.GPaginatorMixin):
+    """Async client to interact with Google Cloud Compute API.
+
+    Attributes:
+        BASE_URL (str): base compute endpoint URL.
+
+    Args:
+        auth_client (gordon_janitor_gcp.auth.GoogleAuthClient): client
+            to manage authentication for HTTP API requests.
+        session (aiohttp.ClientSession): (optional) ``aiohttp`` HTTP
+            session to use for sending requests. Defaults to the
+            session object attached to ``auth_client`` if not provided.
+        api_version (str): version of API endpoint to send requests to.
+        blacklisted_tags (list): Do not collect an instance if it has been
+            tagged with any of these.
+        blacklisted_metadata (list): Do not collect an instance if its metadata
+            key:val matches a {key:val} dict in this list.
+    """
+    BASE_URL = 'https://www.googleapis.com/compute/'
+
+    def __init__(self,
+                 auth_client=None,
+                 session=None,
+                 api_version='v1',
+                 blacklisted_tags=None,
+                 blacklisted_metadata=None):
+        super().__init__(auth_client=auth_client, session=session)
+        self.api_version = api_version
+        self.blacklisted_tags = blacklisted_tags or []
+        self.blacklisted_metadata = blacklisted_metadata or []
+
+    async def list_instances(self,
+                             project,
+                             page_size=500,
+                             instance_filter=None):
+        """Fetch all instances in a GCE project.
+
+        You can find the endpoint documentation
+        `here <https://cloud.google.com/compute/docs/reference/latest/
+        instances/aggregatedList>`__.
+
+        Args:
+            project (str): unique, user-provided project ID.
+            page_size (int): hint for the client to only retrieve up to this
+                number of results per API call.
+            instance_filter (str): endpoint-specific filter string used to
+                retrieve a subset of instances. This is passed directly to the
+                endpoint's "filter" URL query parameter.
+        Returns:
+            list: dicts containing instance data.
+        """
+        url = (f'{self.BASE_URL}{self.api_version}/projects/{project}'
+               '/aggregated/instances')
+        params = {'maxResults': page_size}
+        if instance_filter:
+            params['filter'] = instance_filter
+
+        responses = await self.list_all(url, params)
+        instances = self._parse_rsps_for_instances(responses)
+        return instances
+
+    def _parse_rsps_for_instances(self, responses):
+        instances = []
+        for response in responses:
+            for zone in response.get('items', {}).values():
+                instances.extend(self._filter_zone_instances(zone))
+        return instances
+
+    def _filter_zone_instances(self, zone):
+        instances = []
+        for instance in zone.get('instances', []):
+            if not any([
+                self._blacklisted_by_tag(instance),
+                self._blacklisted_by_metadata(instance)
+            ]):
+                try:
+                    instances.append(self._extract_instance_data(instance))
+                except (KeyError, IndexError) as e:
+                    logging.debug(
+                        'Could not extract instance information for '
+                        f'{instance} because of missing key {e}, skipping.')
+        return instances
+
+    def _extract_instance_data(self, instance):
+        iface_data = instance['networkInterfaces'][0]
+        return {
+            'hostname': instance['name'],
+            'internal_ip': iface_data['networkIP'],
+            'external_ip': iface_data['accessConfigs'][0]['natIP'],
+        }
+
+    def _blacklisted_by_tag(self, instance):
+        instance_tags = instance.get('tags', {}).get('items', [])
+        for tag in instance_tags:
+            if tag in self.blacklisted_tags:
+                msg = (f'Instance "{instance["name"]}" filtered out for '
+                       f'blacklisted tag: "{tag}"')
+                logging.debug(msg)
+                return True
+        return False
+
+    def _blacklisted_by_metadata(self, instance):
+        # NOTE: Both key and value are used when comparing the instance and
+        # blacklist metadata.
+        instance_metadata = instance.get('metadata', {}).get('items', [])
+        for metadata in instance_metadata:
+            for bl_meta in self.blacklisted_metadata:
+                if bl_meta.get(metadata['key']) == metadata['value']:
+                    msg = (f'Instance "{instance["name"]}" filtered out for '
+                           f'blacklisted metadata: "{bl_meta}"')
+                    logging.debug(msg)
+                    return True
+        return False

--- a/gordon_janitor_gcp/http_client.py
+++ b/gordon_janitor_gcp/http_client.py
@@ -169,3 +169,29 @@ class AIOGoogleHTTPClient:
             json_callback = json.loads
         response = await self.request(method='get', url=url, **kwargs)
         return json_callback(response)
+
+
+class GPaginatorMixin:
+    """HTTP client mixin that aggregates data from paginated responses."""
+    async def list_all(self, url, params):
+        """Aggregate data from all pages of an API query.
+
+        Args:
+            url (str): Google API endpoint URL.
+            params (dict): URL query parameters.
+        Returns:
+            list: parsed query response results.
+        """
+        items = []
+        next_page_token = None
+
+        while True:
+            if next_page_token:
+                params['pageToken'] = next_page_token
+            response = await self.get_json(url, params=params)
+
+            items.append(response)
+            next_page_token = response.get('nextPageToken')
+            if not next_page_token:
+                break
+        return items

--- a/tests/unit/test_gcp_clients.py
+++ b/tests/unit/test_gcp_clients.py
@@ -1,0 +1,262 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2018 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import copy
+import logging
+
+import pytest
+from aioresponses import aioresponses
+
+from gordon_janitor_gcp import gcp_clients
+
+
+class TestGCRMClient:
+    @pytest.fixture
+    def patch_crm_url(self, monkeypatch):
+        fake_url = 'https://example.com'
+        class_attribute = 'gordon_janitor_gcp.gcp_clients.GCRMClient.BASE_URL'
+        monkeypatch.setattr(class_attribute, fake_url)
+        return fake_url
+
+    @pytest.fixture
+    def crm_one_page_rsp(self):
+        return {
+            'projects': [
+                {
+                    'projectNumber': '1',
+                    'projectId': 'project-service-1',
+                    'lifecycleState': 'ACTIVE',
+                    'name': 'Project Service 1',
+                    'createTime': '2018-01-01T00:00:00',
+                    'labels': {},
+                    'parent': {}
+                },
+                {
+                    'projectNumber': '2',
+                    'projectId': 'project-service-2',
+                    'lifecycleState': 'ACTIVE',
+                    'name': 'Project Service 2',
+                    'createTime': '2018-02-01T00:00:00',
+                    'labels': {},
+                    'parent': {}
+                }],
+        }
+
+    @pytest.mark.asyncio
+    async def test_list_all_active_projects(
+            self, mocker, crm_one_page_rsp, patch_crm_url, get_gce_client):
+        """Request is made using default parameters."""
+        crm_client = get_gce_client(gcp_clients.GCRMClient)
+
+        api_url = f'{patch_crm_url}/v1/projects?'
+        with aioresponses() as m:
+            m.get(f'{api_url}pageSize=500', payload=crm_one_page_rsp)
+
+            results = await crm_client.list_all_active_projects(
+                page_size=500)
+
+        assert crm_one_page_rsp['projects'] == results
+
+    @pytest.mark.asyncio
+    async def test_list_all_active_projects_multiple_pages(
+            self, mocker, crm_one_page_rsp, patch_crm_url, get_gce_client):
+        """Client successfully retrieves multiple pages of results from API."""
+        crm_client = get_gce_client(gcp_clients.GCRMClient)
+        page2 = copy.deepcopy(crm_one_page_rsp)
+        page2['projects'][0]['projectNumber'] = '3'
+        page2['projects'][1]['projectNumber'] = '4'
+        # This project entry is expected to be filtered out
+        page2['projects'][1]['lifecycleState'] = 'd34d'
+        crm_one_page_rsp['nextPageToken'] = '123token'
+
+        api_url = f'{patch_crm_url}/v1/projects?'
+        with aioresponses() as m:
+            url_with_pagesize = f'{api_url}pageSize=1000'
+            m.get(url_with_pagesize, payload=crm_one_page_rsp)
+            url_with_token = f'{api_url}pageSize=1000&pageToken=123token'
+            m.get(url_with_token, payload=page2)
+
+            results = await crm_client.list_all_active_projects()
+
+        expected_rsp = crm_one_page_rsp['projects']
+        expected_rsp.append(page2['projects'].pop(0))
+        assert expected_rsp == results
+        # assert requests made and their sequence
+        requests = list(m.requests.keys())
+        assert 2 == len(requests)
+        assert ('get', url_with_pagesize) == requests[0]
+        assert ('get', url_with_token) == requests[1]
+
+
+class TestGCPClient:
+    @pytest.fixture
+    def patch_compute_base_url(self, monkeypatch):
+        fake_url = 'http://example.com/compute/'
+        class_attribute = 'gordon_janitor_gcp.gcp_clients.GCEClient.BASE_URL'
+        monkeypatch.setattr(class_attribute, fake_url)
+        return fake_url
+
+    @pytest.fixture
+    def compute_rsp(self):
+        return {
+            'kind': 'compute#instanceAggregatedList',
+            'id': 'd34dbeef',
+            # Simplified Instance resource
+            'items': {
+                'us-west1-z': {
+                    'instances': [{
+                        'id': '1',
+                        'creationTimestamp': '2018-01-01 00:00:00.0000',
+                        'name': 'instance-1',
+                        'description': 'guc3-instance-1-54kj',
+                        'tags': {
+                            'items': ['some-tag'],
+                            'fingerprint': ''
+                        },
+                        'machineType': 'n1-standard-1',
+                        'status': 'RUNNING',
+                        'statusMessage': 'RUNNING',
+                        'zone': 'us-west9-z',
+                        'canIpForward': False,
+                        'networkInterfaces': [{
+                            'network': 'network/url/string',
+                            'subnetwork': 'subnetwork/url/string',
+                            'networkIP': '192.168.0.1',
+                            'name': 'test-network',
+                            'accessConfigs': [{
+                                'type': 'ONE_TO_ONE_NAT',
+                                'name': 'EXTERNAL NAT',
+                                'natIP': '1.1.1.1',
+                                'kind': 'compute#accessConfig'
+                            }],
+                        }],
+                        'metadata': {
+                            'items': [
+                                {'key': 'default', 'value': 'true'}
+                            ],
+                        },
+                    }],
+                    'warning': {
+                        'warning': 'object'
+                    }
+                }
+            },
+        }
+
+    @pytest.mark.parametrize('query_str,instance_meta,log_call_count', [
+        # test one page of results + zone filter
+        ('maxResults=10&filter=zone eq us-west9-z', None, 2),
+        # test instance filtering when filtered by tags
+        ('maxResults=10&filter=', ['bl-tag'], 3),
+        # test instance filtering when filtered by metadata
+        ('maxResults=10&filter=', {'key': 'type', 'value': 'c0ffee-b33f'}, 3),
+    ])
+    @pytest.mark.asyncio
+    async def test_list_instances(
+            self, compute_rsp, patch_compute_base_url, get_gce_client, caplog,
+            query_str, instance_meta, log_call_count):
+        """Client uses multiple filters to process results."""
+        caplog.set_level(logging.DEBUG)
+        gce_client = get_gce_client(gcp_clients.GCEClient)
+
+        if instance_meta:
+            instance_dict = compute_rsp['items']['us-west1-z']['instances'][0]
+            blacklisted_instance = copy.deepcopy(instance_dict)
+            blacklisted_instance['name'] = 'instance-2'
+            compute_rsp['items']['us-west1-z']['instances'].append(
+                blacklisted_instance)
+
+        if isinstance(instance_meta, list):
+            blacklisted_instance['tags']['items'] = instance_meta
+            gce_client.blacklisted_tags.append(instance_meta[0])
+        elif isinstance(instance_meta, dict):
+            blacklisted_instance['metadata']['items'].append(instance_meta)
+            blacklisted_metadata = {
+                instance_meta['key']: instance_meta['value']
+            }
+            gce_client.blacklisted_metadata.append(blacklisted_metadata)
+
+        with aioresponses() as m:
+            filter_url = (f'{patch_compute_base_url}v1/projects/test-project/'
+                          f'aggregated/instances?{query_str}')
+            m.get(filter_url, payload=compute_rsp)
+
+            kwargs = {}
+            if instance_meta is None:
+                kwargs = {'instance_filter': query_str[query_str.find('zone'):]}
+
+            results = await gce_client.list_instances(
+                'test-project',
+                page_size=10,
+                **kwargs)
+
+        expected_results = [{
+            'hostname': 'instance-1',
+            'internal_ip': '192.168.0.1',
+            'external_ip': '1.1.1.1'
+        }]
+        assert expected_results == results
+        assert log_call_count == len(caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_list_instances_bad_json(
+            self, compute_rsp, patch_compute_base_url, get_gce_client, caplog):
+        """Client ignores incomplete API replies."""
+        gce_client = get_gce_client(gcp_clients.GCEClient)
+        caplog.set_level(logging.DEBUG)
+        del compute_rsp['items']['us-west1-z']['instances'][0]['name']
+        with aioresponses() as m:
+            filter_url = (f'{patch_compute_base_url}v1/projects/test-project/'
+                          'aggregated/instances?maxResults=10')
+            m.get(filter_url, payload=compute_rsp)
+
+            results = await gce_client.list_instances(
+                'test-project', page_size=10)
+
+        assert [] == results
+        assert 3 == len(caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_list_instances_retrieves_multiple_pages(
+            self, compute_rsp, patch_compute_base_url, get_gce_client, caplog):
+        """Client successfully retrieves multiple pages of results from API."""
+        gce_client = get_gce_client(gcp_clients.GCEClient)
+        page2 = copy.deepcopy(compute_rsp)
+        page2['items']['us-west1-z']['instances'][0]['name'] = 'instance-2'
+        compute_rsp['nextPageToken'] = '123token123'
+        with aioresponses() as m:
+            filter_url = (f'{patch_compute_base_url}v1/projects/test-project/'
+                          'aggregated/instances?maxResults=5')
+            m.get(filter_url, payload=compute_rsp)
+            url_with_token = (f'{filter_url}&pageToken=123token123')
+            m.get(url_with_token, payload=page2)
+
+            results = await gce_client.list_instances(
+                'test-project', page_size=5)
+
+        expected_results = [{
+            'hostname': 'instance-1',
+            'internal_ip': '192.168.0.1',
+            'external_ip': '1.1.1.1'
+        }]
+        expected_results.append(expected_results[0].copy())
+        expected_results[1]['hostname'] = 'instance-2'
+
+        assert expected_results == results
+        requests = list(m.requests.keys())
+        assert 2 == len(requests)
+        assert ('get', filter_url) == requests[0]
+        assert ('get', url_with_token) == requests[1]

--- a/tests/unit/test_http_client.py
+++ b/tests/unit/test_http_client.py
@@ -30,10 +30,6 @@ from tests.unit import conftest
 logging.getLogger('asyncio').setLevel(logging.WARNING)
 
 
-API_BASE_URL = 'https://example.com'
-API_URL = f'{API_BASE_URL}/v1/foo_endpoint'
-
-
 #####
 # Tests for simple client instantiation
 #####
@@ -62,11 +58,7 @@ def test_http_client_default(provide_session, mocker):
 
 
 @pytest.fixture
-def client(mocker):
-    auth_client = mocker.Mock(auth.GoogleAuthClient, autospec=True)
-    auth_client.token = '0ldc0ffe3'
-    creds = mocker.Mock()
-    auth_client.creds = creds
+def client(mocker, auth_client):
     session = aiohttp.ClientSession()
     client = http_client.AIOGoogleHTTPClient(auth_client=auth_client,
                                              session=session)
@@ -127,13 +119,13 @@ async def test_request(client, monkeypatch, caplog):
     resp_text = 'ohai'
 
     with aioresponses() as mocked:
-        mocked.get(API_URL, status=200, body=resp_text)
-        resp = await client.request('get', API_URL)
+        mocked.get(conftest.API_URL, status=200, body=resp_text)
+        resp = await client.request('get', conftest.API_URL)
 
     assert resp == resp_text
 
     assert 1 == mock_set_valid_token_called
-    request = mocked.requests[('get', API_URL)][0]
+    request = mocked.requests[('get', conftest.API_URL)][0]
     authorization_header = request.kwargs['headers']['Authorization']
     assert authorization_header == f'Bearer {client._auth_client.token}'
     assert 2 == len(caplog.records)
@@ -153,9 +145,9 @@ async def test_request_refresh(client, monkeypatch, caplog):
     resp_text = 'ohai'
 
     with aioresponses() as mocked:
-        mocked.get(API_URL, status=401)
-        mocked.get(API_URL, status=200, body=resp_text)
-        resp = await client.request('get', API_URL)
+        mocked.get(conftest.API_URL, status=401)
+        mocked.get(conftest.API_URL, status=200, body=resp_text)
+        resp = await client.request('get', conftest.API_URL)
 
     assert resp == resp_text
     assert 2 == mock_set_valid_token_called
@@ -174,11 +166,11 @@ async def test_request_max_refresh_reached(client, monkeypatch, caplog):
     monkeypatch.setattr(client, 'set_valid_token', mock_set_valid_token)
 
     with aioresponses() as mocked:
-        mocked.get(API_URL, status=401)
-        mocked.get(API_URL, status=401)
-        mocked.get(API_URL, status=401)
+        mocked.get(conftest.API_URL, status=401)
+        mocked.get(conftest.API_URL, status=401)
+        mocked.get(conftest.API_URL, status=401)
         with pytest.raises(exceptions.GCPHTTPError) as e:
-            await client.request('get', API_URL)
+            await client.request('get', conftest.API_URL)
 
         e.match('Issue connecting to example.com:')
 
@@ -217,8 +209,8 @@ async def test_get_json(json_func, exp_resp, client, monkeypatch, caplog):
     resp_json = '{"hello": "world"}'
 
     with aioresponses() as mocked:
-        mocked.get(API_URL, status=200, body=resp_json)
-        resp = await client.get_json(API_URL, json_func)
+        mocked.get(conftest.API_URL, status=200, body=resp_json)
+        resp = await client.get_json(conftest.API_URL, json_func)
 
     assert exp_resp == resp
     assert 1 == mock_set_valid_token_called


### PR DESCRIPTION
**What this PR does / why we need it**:

This is part of https://github.com/spotify/gordon-janitor-gcp/pull/7 and it contains only the GCP-related clients (GCEClient and GCRMClient). It also includes the pagination mixin for the http client.

**Which issue(s) this PR fixes**
<!-- optional; in `fixes #<issue number>, fixes #<issue_number>, ...` format, will close the issue(s) when PR gets merged: -->
N/A

**Special notes for your reviewer**:
I addressed all the feedback from #7:
- Removed the retry logic from the pagination mixin.
- Renamed things to be in line [with this comment](https://github.com/spotify/gordon-janitor-gcp/pull/7#discussion_r169642245).
- Simplified the GPaginatorMixin.
- Used rst for docstring links.
- Handful of typos and docstring fixes ([like this one](https://github.com/spotify/gordon-janitor-gcp/pull/7#discussion_r169479260))

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

@spotify/alf 
