### PR TITLE
Fix AIOGoogleHTTPClient token setting

### DIFF
--- a/gordon_janitor_gcp/http_client.py
+++ b/gordon_janitor_gcp/http_client.py
@@ -110,7 +110,7 @@ class AIOGoogleHTTPClient:
 
         await self.set_valid_token()
         req_headers.update(
-            {'Authorization': f'Bearer {self._auth_client.creds.token}'}
+            {'Authorization': f'Bearer {self._auth_client.token}'}
         )
 
         req_kwargs = {

--- a/tests/unit/test_http_client.py
+++ b/tests/unit/test_http_client.py
@@ -71,8 +71,8 @@ class MockDatetime(datetime.datetime):
 @pytest.fixture
 def client(mocker):
     auth_client = mocker.Mock(auth.GoogleAuthClient, autospec=True)
+    auth_client.token = '0ldc0ffe3'
     creds = mocker.Mock()
-    creds.token = '0ldc0ffe3'
     auth_client.creds = creds
     session = aiohttp.ClientSession()
     client = http_client.AIOGoogleHTTPClient(auth_client=auth_client,
@@ -138,7 +138,11 @@ async def test_request(client, monkeypatch, caplog):
         resp = await client.request('get', API_URL)
 
     assert resp == resp_text
+
     assert 1 == mock_set_valid_token_called
+    request = mocked.requests[('get', API_URL)][0]
+    authorization_header = request.kwargs['headers']['Authorization']
+    assert authorization_header == f'Bearer {client._auth_client.token}'
     assert 2 == len(caplog.records)
 
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines <https://github.com/spotify/gordon-janitor-gcp/blob/master/CONTRIBUTING.rst>
2. If the PR is unfinished, please prefix the subject line with [WIP], [DRAFT], or [RFC].
-->

**What this PR does / why we need it**:

This PR makes sure that AIOGoogleHTTPClient sets the authorization using the [token fetched by the auth client](https://github.com/spotify/gordon-janitor-gcp/blob/develop/gordon_janitor_gcp/auth.py#L166). Without this patch, the http client makes requests with the header set to ```Authorization: Bearer None```.

**Which issue(s) this PR fixes**
<!-- optional; in `fixes #<issue number>, fixes #<issue_number>, ...` format, will close the issue(s) when PR gets merged: -->
N/A

**Special notes for your reviewer**:

N/A

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

@spotify/alf 