### PR TITLE
Add GCE authority plugin

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -39,7 +39,7 @@ Any configuration key/value listed here may also be used in the specific plugin 
 
     To learn more about GCP projects, please see `Google's docs on creating & managing projects <https://cloud.google.com/resource-manager/docs/creating-managing-projects>`_.
 
-.. option:: scopes=["STR", "STR"]
+.. option:: scopes=["STR","STR"]
 
     `Optional`: A list of strings of the scope(s) needed when making calls to Google APIs. Defaults to ``["cloud-platform"]``.
 
@@ -66,5 +66,32 @@ All configuration options above in the general ``[gcp]`` may be used here. Addit
 
     For the Pub/Sub plugin, ``keyfile`` is not required when running against the `Pub/Sub Emulator <https://cloud.google.com/pubsub/docs/emulator>`_ that Google provides.
 
+
+gcp.gce
+~~~~~~~
+
+All configuration options from the general ``[gcp]`` section may be used here.
+
+Additional plugin-specific configuration is needed:
+
+.. option:: zone="STR"
+
+    `Required`: ID of a Cloud DNS managed zone that instance resource records should belong to.
+
+.. option:: metadata_blackklist=[["STR","STR"],["STR","STR"]]
+
+    `Optional`: List of key-value pairs that will be used to filter out unwanted GCE instances by `instance metadata <https://cloud.google.com/compute/docs/storing-retrieving-metadata>`_. Note that both the key and the value must match for an instance to be filtered out.
+
+.. option:: tag_blacklist=["STR","STR"]
+
+    `Optional`: List of `network tags <https://cloud.google.com/vpc/docs/add-remove-network-tags>`_  that will be used to filter out unwanted GCE instances.
+
+.. option:: project_blacklist=["STR","STR"]
+
+    `Optional`: List of unique, user-assigned project IDs (``projectId``) that will be ignored when fetching projects.
+
+.. option:: instance_filter="STR"
+
+    `Optional`: String used to filter instances by instance attributes. It is passed directly to GCE's `v1.instances.aggregatedList <https://cloud.google.com/compute/docs/reference/rest/v1/instances/aggregatedList>`_ endpoint's `filter` parameter.
 
 .. _`gordon-janitor`: https://github.com/spotify/gordon-janitor

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -26,5 +26,11 @@ Publisher
 .. autoclass:: gordon_janitor_gcp.GPubsubPublisher
     :members:
 
+Authority
+---------
+
+.. automodule:: gordon_janitor_gcp.plugins.authority
+.. autoclass:: gordon_janitor_gcp.GCEAuthority
+    :members:
 
 .. _`gordon-janitor`: https://github.com/spotify/gordon-janitor

--- a/gordon-janitor.toml.example
+++ b/gordon-janitor.toml.example
@@ -14,3 +14,13 @@ scopes = ["ndev.clouddns.readonly"]
 keyfile = "/path/to/pubsub-service-account.json"
 project = "gordon-pubsub-example"
 topic = "dns-changes-topic"
+
+[gcp.gce]
+keyfile = "/path/to/crm-service-account.json"
+scopes = ["cloud-platform"]
+zone = "example.com"
+metadata_blacklist = [["key", "val"], ["other_key", "other_val"]]
+tag_blacklist = []
+project_blacklist = []
+# This is passed directly to GCE's v1.instances.aggregatedList endpoint
+instance_filter = ""

--- a/gordon_janitor_gcp/plugins/__init__.py
+++ b/gordon_janitor_gcp/plugins/__init__.py
@@ -15,8 +15,10 @@
 # limitations under the License.
 
 # Mainly for easier documentation reading
+from gordon_janitor_gcp.plugins import authority
 from gordon_janitor_gcp.plugins import publisher
 from gordon_janitor_gcp.plugins import reconciler
+from gordon_janitor_gcp.plugins.authority import GCEAuthority  # noqa: F401
 from gordon_janitor_gcp.plugins.publisher import GPubsubPublisher  # noqa: F401
 from gordon_janitor_gcp.plugins.reconciler import GDNSReconciler  # noqa: F401
 
@@ -24,7 +26,8 @@ from gordon_janitor_gcp.plugins.reconciler import GDNSReconciler  # noqa: F401
 __all__ = (
     reconciler.__all__ +  # noqa: F405
     ('get_publisher', 'GPubsubPublisher') +
-    ('get_reconciler', 'GDNSReconciler')
+    ('get_reconciler', 'GDNSReconciler') +
+    ('get_authority', 'GCEAuthority')
 )
 
 
@@ -69,3 +72,22 @@ def get_reconciler(config, rrset_channel, changes_channel, **kw):
     builder = reconciler.GDNSReconcilerBuilder(
         config, rrset_channel, changes_channel, **kw)
     return builder.build_reconciler()
+
+
+def get_authority(config, rrset_channel, **kwargs):
+    """Get a GCEAuthority client.
+
+    A factory function that validates configuration and creates a
+    proper GCEAuthority.
+
+    Args:
+        config (dict): GCEAuthority related configuration.
+        rrset_channel (asyncio.Queue): queue used for sending messages
+            to the reconciler plugin.
+        kw (dict): Additional keyword arguments to pass to the
+            Authority.
+    Returns:
+        A :class:`GCEAuthority` instance.
+    """
+    builder = authority.GCEAuthorityBuilder(config, rrset_channel, **kwargs)
+    return builder.build_authority()

--- a/gordon_janitor_gcp/plugins/authority.py
+++ b/gordon_janitor_gcp/plugins/authority.py
@@ -1,0 +1,182 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2018 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+A GCEAuthority retrieves a list of all instances in all projects that it has
+access to, and which belong to the configured zone. For every project, it will
+create a message containing domain record information and put it into the
+rrset channel. Projects can be filtered by 'project name'. Instances can be
+filtered by tags and metadata.
+
+To use:
+
+.. code-block:: python
+
+    import asyncio
+
+    from gordon_janitor_gcp import plugins
+
+    async def run():
+        rrset_channel = asyncio.queue()
+        authority = plugins.get_authority(config, rrset_channel)
+        await authority.start()
+        msg = await rrset_channel.get()
+        print(msg)
+
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(run())
+    # prints: {'zone': 'example.com', 'resourceRecords': [...]}
+"""
+
+import logging
+
+import aiohttp
+import zope.interface
+from gordon_janitor import interfaces
+
+from gordon_janitor_gcp import exceptions
+from gordon_janitor_gcp.clients import auth
+from gordon_janitor_gcp.clients import gce
+from gordon_janitor_gcp.clients import gcrm
+
+
+class GCEAuthorityBuilder:
+    """Build and configure a :class:`GCEAuthority` object.
+
+    Args:
+        config (dict): plugin-specific configuration.
+        rrset_channel (asyncio.Queue): channel to send resource record messages
+            to.
+    """
+    def __init__(self, config, rrset_channel, **kwargs):
+        self.config = config
+        self.rrset_channel = rrset_channel
+        self.kwargs = kwargs
+        self.session = None
+
+    def _get_crm_client(self, keyfile_path, scopes):
+        crm_auth = auth.GAuthClient(
+            keyfile_path, scopes=scopes, session=self.session)
+        return gcrm.GCRMClient(crm_auth, self.session)
+
+    def _get_gce_client(self, keyfile_path, scopes):
+        tag_blacklist = self.config.get('tag_blacklist', [])
+        _metadata_blacklist = self.config.get('metadata_blacklist', [])
+        metadata_blacklist = [dict([pair]) for pair in _metadata_blacklist]
+
+        gce_auth = auth.GAuthClient(keyfile_path, scopes=scopes,
+                                    session=self.session)
+        return gce.GCEClient(gce_auth, self.session,
+                             blacklisted_tags=tag_blacklist,
+                             blacklisted_metadata=metadata_blacklist)
+
+    def _validate_config(self):
+        if not self.config.get('keyfile'):
+            msg = ('The path to a Service Account JSON keyfile is required to '
+                   'authenticate to Google Compute Engine and Cloud '
+                   'Resource Manager.')
+            logging.error(msg)
+            raise exceptions.GCPConfigError(msg)
+        if not self.config.get('zone'):
+            msg = ('The ID of the target Cloud DNS managed zone is required to '
+                   'identify which zone records should belong to.')
+            logging.error(msg)
+            raise exceptions.GCPConfigError(msg)
+
+    def build_authority(self):
+        self._validate_config()
+        keyfile_path = self.config['keyfile']
+        scopes = self.config.get('scopes')
+        self.session = aiohttp.ClientSession()
+        crm_client = self._get_crm_client(keyfile_path, scopes)
+        gce_client = self._get_gce_client(keyfile_path, scopes)
+
+        return GCEAuthority(self.config, crm_client, gce_client,
+                            self.rrset_channel, **self.kwargs)
+
+
+@zope.interface.implementer(interfaces.IAuthority)
+class GCEAuthority:
+    """Gather instance data from GCE.
+
+    Args:
+        config (dict): plugin-specific configuration.
+        crm_client (.GCRMClient): client used to fetch GCE projects.
+        gce_client (.GCEClient): client used to fetch instances for a project.
+        rrset_channel (asyncio.Queue): channel to send resource record messages
+            to.
+    """
+
+    def __init__(self, config, crm_client, gce_client, rrset_channel=None,
+                 **kwargs):
+        self.config = config
+        self.crm_client = crm_client
+        self.gce_client = gce_client
+        self.rrset_channel = rrset_channel
+
+    async def _get_active_project_ids(self):
+        active_projects = await self.crm_client.list_all_active_projects()
+        return set(p.get('projectId') for p in active_projects)
+
+    async def _get_projects(self):
+        projects = await self._get_active_project_ids()
+        project_blacklist = set(self.config.get('project_blacklist', []))
+        # TODO: emit a metric for all projects and a metric for
+        # project - blacklist.
+        return sorted(projects - project_blacklist)
+
+    async def _get_instances(self, projects):
+        instance_filter = self.config.get('instance_filter')
+        for project in projects:
+            yield await self.gce_client.list_instances(
+                project, instance_filter=instance_filter)
+
+    def _create_instance_rrset(self, instance):
+        return {
+            'name': instance['hostname'],
+            'type': 'A',
+            'rrdatas': [instance['external_ip']]
+        }
+
+    def _create_msg(self, instances):
+        return {
+            'zone': self.config['zone'],
+            'rrsets': [
+                self._create_instance_rrset(instance_data)
+                for instance_data in instances
+            ]
+        }
+
+    async def start(self):
+        """Batch instance data and send it to the :obj:`self.rrset_channel`.
+        """
+        projects = await self._get_projects()
+
+        instances = []
+        async for project_instances in self._get_instances(projects):
+            instances.extend(project_instances)
+
+        rrset_msg = self._create_msg(instances)
+        await self.rrset_channel.put(rrset_msg)
+        # TODO: emit a metric of domain records created per zone and project.
+
+        await self.done()
+
+    async def done(self):
+        """Clean up after a run."""
+        msg = 'Finished sending record messages to the reconciler.'
+        logging.info(msg)
+        await self.rrset_channel.put(None)
+        await self.gce_client._session.close()

--- a/setup.py
+++ b/setup.py
@@ -95,6 +95,7 @@ setup(
     packages=PACKAGES,
     entry_points={
         'gordon_janitor.plugins': [
+            'gcp.gce = gordon_janitor:get_authority',
             'gcp.gdns = gordon_janitor_gcp:get_reconciler',
             'gcp.gpubsub = gordon_janitor_gcp:get_publisher',
         ],

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -124,13 +124,15 @@ def auth_client(mocker, monkeypatch):
 
 
 @pytest.fixture
-def mock_coro(mocker):
-    mock = mocker.Mock()
+def create_mock_coro(mocker):
+    def _create_mock_coro():
+        mock = mocker.Mock()
 
-    async def _coro(*args, **kwargs):
-        return mock(*args, **kwargs)
+        async def _coro(*args, **kwargs):
+            return mock(*args, **kwargs)
 
-    return mock, _coro
+        return mock, _coro
+    return _create_mock_coro
 
 
 async def _noop():
@@ -139,10 +141,8 @@ async def _noop():
 
 @pytest.fixture
 def get_gce_client(mocker, auth_client):
-    client = None
 
     def _create_client(klass, *args, **kwargs):
-        nonlocal client
         client = klass(auth_client, *args, **kwargs)
         mocker.patch.object(client, 'set_valid_token', _noop)
         return client
@@ -155,3 +155,15 @@ def publisher_client(mocker, monkeypatch):
     patch = 'gordon_janitor_gcp.plugins.publisher.pubsub.PublisherClient'
     monkeypatch.setattr(patch, mock)
     return mock
+
+
+@pytest.fixture
+def authority_config():
+    return {
+        'keyfile': 'keyfile',
+        'scopes': ['scope'],
+        'metadata_blacklist': [['key', 'val'], ['other_key', 'other_val']],
+        'project_blacklist': [],
+        'tag_blacklist': [],
+        'zone': 'zone1',
+    }

--- a/tests/unit/plugins/test_authority.py
+++ b/tests/unit/plugins/test_authority.py
@@ -1,0 +1,135 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2018 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+
+import pytest
+
+from gordon_janitor_gcp.clients import gce
+from gordon_janitor_gcp.clients import gcrm
+from gordon_janitor_gcp.plugins import authority
+
+
+def echoing_helper_coro(data):
+    async def _coro():
+        return data
+    return _coro()
+
+
+@pytest.fixture
+def fake_authority(mocker, monkeypatch, authority_config, auth_client):
+    monkeypatch.setattr('gordon_janitor_gcp.plugins.auth.GAuthClient',
+                        mocker.Mock(return_value=auth_client))
+    rrset_channel = asyncio.Queue()
+    fake_authority = authority.GCEAuthority(
+        authority_config, rrset_channel)
+    fake_authority.session = auth_client._session
+    return fake_authority
+
+
+@pytest.fixture
+def get_mock_client(mocker, get_gce_client):
+    def _create_fake(klass, *args, **kwargs):
+        client = get_gce_client(klass, *args, **kwargs)
+        fake_client = mocker.Mock(client)
+        return fake_client
+    return _create_fake
+
+
+@pytest.mark.asyncio
+async def test_builder_creates_proper_authority(mocker, authority_config):
+    gce_client = mocker.MagicMock(name='gce_client')
+    crm_client = mocker.MagicMock(name='crm_client')
+    auth_client = mocker.MagicMock(name='auth_client')
+    authority_mod_patch = 'gordon_janitor_gcp.clients.'
+    mocker.patch(authority_mod_patch + 'gcrm.GCRMClient', crm_client)
+    mocker.patch(authority_mod_patch + 'gce.GCEClient', gce_client)
+    mocker.patch(authority_mod_patch + 'auth.GAuthClient', auth_client)
+
+    rrset_channel = asyncio.Queue()
+    kwargs = {'other': 'kwargs'}
+    builder = authority.GCEAuthorityBuilder(
+        authority_config, rrset_channel, **kwargs)
+    try:
+        gce_authority = builder.build_authority()
+    finally:
+        builder.session.close()
+
+    auth_client_calls = [
+        mocker.call(
+            authority_config['keyfile'],
+            scopes=authority_config['scopes'],
+            session=builder.session),
+    ] * 2
+
+    auth_client.assert_has_calls(auth_client_calls, any_order=True)
+    expected_metadata_blacklist = [
+        dict([pair]) for pair in authority_config['metadata_blacklist']
+    ]
+    gce_client.assert_called_once_with(
+        auth_client(),
+        builder.session,
+        blacklisted_tags=authority_config['tag_blacklist'],
+        blacklisted_metadata=expected_metadata_blacklist)
+
+    assert crm_client() is gce_authority.crm_client
+    assert gce_client() is gce_authority.gce_client
+    assert rrset_channel is gce_authority.rrset_channel
+    assert authority_config is gce_authority.config
+
+
+@pytest.mark.asyncio
+async def test_start_publishes_msg_to_channel(mocker, authority_config,
+                                              get_gce_client, create_mock_coro):
+    instance_data = []
+    for i in range(1, 4):
+        instance_data.append({
+            'hostname': f'host-{i}',
+            'internal_ip': f'192.168.1.{i}',
+            'external_ip': f'1.1.1.{i}'})
+
+    active_projects_mock, active_projects_coro = create_mock_coro()
+    active_projects_mock.return_value = [{'projectId': 1}, {'projectId': 2}]
+    crm_client = get_gce_client(gcrm.GCRMClient)
+    crm_client.list_all_active_projects = active_projects_coro
+
+    list_instances_mock, list_instances_coro = create_mock_coro()
+    list_instances_mock.return_value = instance_data
+    gce_client = get_gce_client(gce.GCEClient)
+    gce_client.list_instances = list_instances_coro
+
+    rrset_channel = asyncio.Queue()
+    gce_authority = authority.GCEAuthority(authority_config, crm_client,
+                                           gce_client, rrset_channel)
+
+    await gce_authority.start()
+
+    _expected_rrsets = []
+    for instance in instance_data:
+        _expected_rrsets.append({
+            'name': instance['hostname'],
+            'type': 'A',
+            'rrdatas': [instance['external_ip']]})
+    expected_rrsets = _expected_rrsets * 2
+    expected_msg = {
+        'zone': authority_config['zone'],
+        'rrsets': expected_rrsets
+    }
+
+    # one message includes data for all projects
+    assert expected_msg == (await rrset_channel.get())
+    # start also calls self.done at the end
+    assert (await rrset_channel.get()) is None

--- a/tests/unit/plugins/test_init.py
+++ b/tests/unit/plugins/test_init.py
@@ -145,3 +145,28 @@ def test_get_reconciler_config_raises(key, error_msg, config, auth_client,
 
     e.match(error_msg)
     assert 1 == len(caplog.records)
+
+
+def test_get_authority(authority_config, auth_client):
+    """Test authority client initialization happy path."""
+    rrset_channel = asyncio.Queue()
+
+    client = plugins.get_authority(authority_config, rrset_channel)
+    assert rrset_channel == client.rrset_channel
+    assert client.crm_client is not None
+    assert client.gce_client is not None
+
+
+@pytest.mark.parametrize('config_key,error_msg', [
+    ('keyfile', 'The path to a Service Account JSON keyfile is required '),
+    ('zone', 'The ID of the target Cloud DNS managed zone is required ')])
+def test_get_authority_config_raises(caplog, config_key, error_msg,
+                                     authority_config, auth_client):
+    """Raise with bad configuration."""
+    rrset_channel = asyncio.Queue()
+    del authority_config[config_key]
+    with pytest.raises(exceptions.GCPConfigError) as e:
+        plugins.get_authority(authority_config, rrset_channel)
+
+    e.match(error_msg)
+    assert 1 == len(caplog.records)


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds the `GCEAuthority` plugin, which first fetches and filters instance data from GCE, then creates messages to send to the reconciler plugin.

**Which issue(s) this PR fixes**
<!-- optional; in `fixes #<issue number>, fixes #<issue_number>, ...` format, will close the issue(s) when PR gets merged: -->
None.

**Special notes for your reviewer**:

This set of changes includes the feedback that I received on #7. One item that I think we should discuss in person is what zone information the reconciler plugin expects and how this will affect instance filtering.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

@spotify/alf 
