### PR TITLE
Change GCE default data

### DIFF
--- a/gordon-janitor.toml.example
+++ b/gordon-janitor.toml.example
@@ -18,7 +18,7 @@ topic = "dns-changes-topic"
 [gcp.gce]
 keyfile = "/path/to/crm-service-account.json"
 scopes = ["cloud-platform"]
-zone = "example.com"
+dns_zone = "example.com"
 metadata_blacklist = [["key", "val"], ["other_key", "other_val"]]
 tag_blacklist = []
 project_blacklist = []

--- a/src/gordon_janitor_gcp/clients/gce.py
+++ b/src/gordon_janitor_gcp/clients/gce.py
@@ -131,21 +131,8 @@ class GCEClient(http.AIOConnection,
                 self._blacklisted_by_tag(instance),
                 self._blacklisted_by_metadata(instance)
             ]):
-                try:
-                    instances.append(self._extract_instance_data(instance))
-                except (KeyError, IndexError) as e:
-                    logging.debug(
-                        'Could not extract instance information for '
-                        f'{instance} because of missing key {e}, skipping.')
+                instances.append(instance)
         return instances
-
-    def _extract_instance_data(self, instance):
-        iface_data = instance['networkInterfaces'][0]
-        return {
-            'hostname': instance['name'],
-            'internal_ip': iface_data['networkIP'],
-            'external_ip': iface_data['accessConfigs'][0]['natIP'],
-        }
 
     def _blacklisted_by_tag(self, instance):
         instance_tags = instance.get('tags', {}).get('items', [])

--- a/src/gordon_janitor_gcp/plugins/authority.py
+++ b/src/gordon_janitor_gcp/plugins/authority.py
@@ -89,9 +89,9 @@ class GCEAuthorityBuilder:
                    'Resource Manager.')
             logging.error(msg)
             raise exceptions.GCPConfigError(msg)
-        if not self.config.get('zone'):
-            msg = ('The ID of the target Cloud DNS managed zone is required to '
-                   'identify which zone records should belong to.')
+        if not self.config.get('dns_zone'):
+            msg = ('The DNS zone name, i.e. "example.com", is required to '
+                   'identify to which zone generated records should belong.')
             logging.error(msg)
             raise exceptions.GCPConfigError(msg)
 
@@ -152,7 +152,7 @@ class GCEAuthority:
 
     def _create_msgs(self, instances):
         return [{
-            'zone': self.config['zone'],
+            'zone': self.config['dns_zone'],
             'rrsets': [
                 self._create_instance_rrset(instance_data)
                 for instance_data in instances

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -165,5 +165,5 @@ def authority_config():
         'metadata_blacklist': [['key', 'val'], ['other_key', 'other_val']],
         'project_blacklist': [],
         'tag_blacklist': [],
-        'zone': 'zone1',
+        'dns_zone': 'zone1.com',
     }

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -167,3 +167,39 @@ def authority_config():
         'tag_blacklist': [],
         'dns_zone': 'zone1.com',
     }
+
+
+@pytest.fixture
+def instance_data():
+    return {
+        'id': '1',
+        'creationTimestamp': '2018-01-01 00:00:00.0000',
+        'name': 'instance-1',
+        'description': 'guc3-instance-1-54kj',
+        'tags': {
+            'items': ['some-tag'],
+            'fingerprint': ''
+        },
+        'machineType': 'n1-standard-1',
+        'status': 'RUNNING',
+        'statusMessage': 'RUNNING',
+        'zone': 'us-west9-z',
+        'canIpForward': False,
+        'networkInterfaces': [{
+            'network': 'network/url/string',
+            'subnetwork': 'subnetwork/url/string',
+            'networkIP': '192.168.0.1',
+            'name': 'test-network',
+            'accessConfigs': [{
+                'type': 'ONE_TO_ONE_NAT',
+                'name': 'EXTERNAL NAT',
+                'natIP': '1.1.1.1',
+                'kind': 'compute#accessConfig'
+            }],
+        }],
+        'metadata': {
+            'items': [
+                {'key': 'default', 'value': 'true'}
+            ],
+        },
+    }

--- a/tests/unit/plugins/test_authority.py
+++ b/tests/unit/plugins/test_authority.py
@@ -15,6 +15,8 @@
 # limitations under the License.
 
 import asyncio
+import copy
+import logging
 
 import pytest
 
@@ -31,11 +33,12 @@ def echoing_helper_coro(data):
 
 @pytest.fixture
 def fake_authority(mocker, monkeypatch, authority_config, auth_client):
-    monkeypatch.setattr('gordon_janitor_gcp.plugins.auth.GAuthClient',
-                        mocker.Mock(return_value=auth_client))
+    monkeypatch.setattr(
+        'gordon_janitor_gcp.plugins.authority.auth.GAuthClient',
+        mocker.Mock(return_value=auth_client))
     rrset_channel = asyncio.Queue()
     fake_authority = authority.GCEAuthority(
-        authority_config, rrset_channel)
+        authority_config, None, rrset_channel)
     fake_authority.session = auth_client._session
     return fake_authority
 
@@ -93,13 +96,14 @@ async def test_builder_creates_proper_authority(mocker, authority_config):
 
 @pytest.mark.asyncio
 async def test_run_publishes_msg_to_channel(mocker, authority_config,
-                                            get_gce_client, create_mock_coro):
-    instance_data = []
+                                            get_gce_client, create_mock_coro,
+                                            instance_data):
+    instances = []
     for i in range(1, 4):
-        instance_data.append({
-            'hostname': f'host-{i}',
-            'internal_ip': f'192.168.1.{i}',
-            'external_ip': f'1.1.1.{i}'})
+        inst = copy.deepcopy(instance_data)
+        inst['name'] = f'host-{i}'
+        inst['networkInterfaces'][0]['accessConfigs'][0]['natIp'] = f'1.1.1.{i}'
+        instances.append(inst)
 
     active_projects_mock, active_projects_coro = create_mock_coro()
     active_projects_mock.return_value = [{'projectId': 1}, {'projectId': 2}]
@@ -107,7 +111,7 @@ async def test_run_publishes_msg_to_channel(mocker, authority_config,
     crm_client.list_all_active_projects = active_projects_coro
 
     list_instances_mock, list_instances_coro = create_mock_coro()
-    list_instances_mock.return_value = instance_data
+    list_instances_mock.return_value = instances
     gce_client = get_gce_client(gce.GCEClient)
     gce_client.list_instances = list_instances_coro
 
@@ -118,11 +122,12 @@ async def test_run_publishes_msg_to_channel(mocker, authority_config,
     await gce_authority.run()
 
     _expected_rrsets = []
-    for instance in instance_data:
+    for instance in instances:
+        ip = instance['networkInterfaces'][0]['accessConfigs'][0]['natIP']
         _expected_rrsets.append({
-            'name': instance['hostname'],
+            'name': instance['name'],
             'type': 'A',
-            'rrdatas': [instance['external_ip']]})
+            'rrdatas': [ip]})
     expected_rrsets = _expected_rrsets * 2
     expected_msg = {
         'zone': authority_config['dns_zone'],
@@ -133,3 +138,12 @@ async def test_run_publishes_msg_to_channel(mocker, authority_config,
     assert expected_msg == (await rrset_channel.get())
     # run also calls self.cleanup at the end
     assert (await rrset_channel.get()) is None
+
+
+def test_create_msgs_bad_json(caplog, fake_authority):
+    """Authority ignores incomplete instance data."""
+    caplog.set_level(logging.WARN)
+    partial_instance = {'name': 'incomplete-instance-1'}
+    results = fake_authority._create_msgs([partial_instance])
+    assert [] == results
+    assert 1 == len(caplog.records)

--- a/tests/unit/plugins/test_authority.py
+++ b/tests/unit/plugins/test_authority.py
@@ -125,7 +125,7 @@ async def test_run_publishes_msg_to_channel(mocker, authority_config,
             'rrdatas': [instance['external_ip']]})
     expected_rrsets = _expected_rrsets * 2
     expected_msg = {
-        'zone': authority_config['zone'],
+        'zone': authority_config['dns_zone'],
         'rrsets': expected_rrsets
     }
 

--- a/tests/unit/plugins/test_init.py
+++ b/tests/unit/plugins/test_init.py
@@ -164,7 +164,7 @@ async def test_get_authority(authority_config, auth_client):
 
 @pytest.mark.parametrize('config_key,error_msg', [
     ('keyfile', 'The path to a Service Account JSON keyfile is required '),
-    ('zone', 'The ID of the target Cloud DNS managed zone is required ')])
+    ('dns_zone', 'The DNS zone name, i.e. "example.com", is required to ')])
 def test_get_authority_config_raises(caplog, config_key, error_msg,
                                      authority_config, auth_client):
     """Raise with bad configuration."""


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines <https://github.com/spotify/gordon-janitor-gcp/blob/master/CONTRIBUTING.rst>
2. If the PR is unfinished, please prefix the subject line with [WIP], [DRAFT], or [RFC].
-->

**What this PR does / why we need it**:
This PR makes two changes:
- Renames GCEAuthority config key 'zone' -> 'dns_zone' to avoid confusion with Google Compute zones. 
- Moves the extraction of GCE instance data from the client to the authority, so that any plugins that wish to use this client have access to all the info GCE provides, not just what this authority deems relevant.

**Which issue(s) this PR fixes**
<!-- optional; in `fixes #<issue number>, fixes #<issue_number>, ...` format, will close the issue(s) when PR gets merged: -->
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
