### PR TITLE
Make config requirements the same as for gordon-dns-gcp

### DIFF
--- a/gordon-janitor.toml.example
+++ b/gordon-janitor.toml.example
@@ -18,7 +18,7 @@ topic = "dns-changes-topic"
 [gcp.gce]
 keyfile = "/path/to/crm-service-account.json"
 scopes = ["cloud-platform"]
-dns_zone = "example.com"
+dns_zone = "example.com."
 metadata_blacklist = [["key", "val"], ["other_key", "other_val"]]
 tag_blacklist = []
 project_blacklist = []

--- a/src/gordon_janitor_gcp/plugins/authority.py
+++ b/src/gordon_janitor_gcp/plugins/authority.py
@@ -90,7 +90,7 @@ class GCEAuthorityBuilder:
             logging.error(msg)
             raise exceptions.GCPConfigError(msg)
         if not self.config.get('dns_zone'):
-            msg = ('The DNS zone name, i.e. "example.com", is required to '
+            msg = ('The absolute DNS zone, i.e. "example.com.", is required to '
                    'identify to which zone generated records should belong.')
             logging.error(msg)
             raise exceptions.GCPConfigError(msg)

--- a/tests/unit/plugins/test_init.py
+++ b/tests/unit/plugins/test_init.py
@@ -164,7 +164,7 @@ async def test_get_authority(authority_config, auth_client):
 
 @pytest.mark.parametrize('config_key,error_msg', [
     ('keyfile', 'The path to a Service Account JSON keyfile is required '),
-    ('dns_zone', 'The DNS zone name, i.e. "example.com", is required to ')])
+    ('dns_zone', 'The absolute DNS zone, i.e. "example.com.", is required ')])
 def test_get_authority_config_raises(caplog, config_key, error_msg,
                                      authority_config, auth_client):
     """Raise with bad configuration."""


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines <https://github.com/spotify/gordon-janitor-gcp/blob/master/CONTRIBUTING.rst>
2. If the PR is unfinished, please prefix the subject line with [WIP], [DRAFT], or [RFC].
-->

**What this PR does / why we need it**:
Makes the format of the config parameter `dns_zone` the [same as is used for plugins in Gordon core](https://github.com/spotify/gordon-gcp/blob/develop/src/gordon_gcp/plugins/enricher.py#L78). 

**Which issue(s) this PR fixes**
<!-- optional; in `fixes #<issue number>, fixes #<issue_number>, ...` format, will close the issue(s) when PR gets merged: -->
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ".
2. If no release note is required, just write "NONE".
-->
```release-note
```
