### PR TITLE
Use fully qualified names in Authority records

### DIFF
--- a/src/gordon_janitor_gcp/plugins/authority.py
+++ b/src/gordon_janitor_gcp/plugins/authority.py
@@ -145,8 +145,9 @@ class GCEAuthority:
 
     def _create_instance_rrset(self, instance):
         ip = instance['networkInterfaces'][0]['accessConfigs'][0]['natIP']
+        fqdn = f"{instance['name']}.{self.config['dns_zone']}"
         return {
-            'name': instance['name'],
+            'name': fqdn,
             'type': 'A',
             'rrdatas': [ip]
         }

--- a/tests/unit/plugins/test_authority.py
+++ b/tests/unit/plugins/test_authority.py
@@ -125,7 +125,7 @@ async def test_run_publishes_msg_to_channel(mocker, authority_config,
     for instance in instances:
         ip = instance['networkInterfaces'][0]['accessConfigs'][0]['natIP']
         _expected_rrsets.append({
-            'name': instance['name'],
+            'name': f"{instance['name']}.{authority_config['dns_zone']}",
             'type': 'A',
             'rrdatas': [ip]})
     expected_rrsets = _expected_rrsets * 2


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines <https://github.com/spotify/gordon-janitor-gcp/blob/master/CONTRIBUTING.rst>
2. If the PR is unfinished, please prefix the subject line with [WIP], [DRAFT], or [RFC].
-->

**What this PR does / why we need it**:
Used fully qualified names in Authority records as is expected by the Gordon core event consumer https://github.com/spotify/gordon-gcp/blob/develop/src/gordon_gcp/schema/schemas/event.schema.json#L27


**Which issue(s) this PR fixes**
<!-- optional; in `fixes #<issue number>, fixes #<issue_number>, ...` format, will close the issue(s) when PR gets merged: -->
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ".
2. If no release note is required, just write "NONE".
-->
```release-note

```
